### PR TITLE
fix: Update tag handling in Qiita and Zenn article cards

### DIFF
--- a/components/composites/qiita-article-card/qiita-article-card.tsx
+++ b/components/composites/qiita-article-card/qiita-article-card.tsx
@@ -39,7 +39,7 @@ export function QiitaArticleCard({ article }: QiitaArticleCardProps) {
             <MdxHeading as="h2">{article.title}</MdxHeading>
           </Link>
           <div className="flex items-center gap-4 mt-2">
-            <TagList tags={article.tags.map((tag) => tag.name)} />
+            <TagList tags={article.tags.length > 0 ? [article.tags[0].name] : []} />
             <Time date={article.created_at} />
             <span className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-1">
               <Heart className="w-4 h-4" />

--- a/components/composites/zenn-article-card/zenn-article-card.tsx
+++ b/components/composites/zenn-article-card/zenn-article-card.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Time } from '@/components/elements/time/time';
 import { MdxHeading } from '@/components/mdx/heading/heading';
 import type { ZennArticle } from '@/utils/zenn';
+import { TagList } from '../tag-list';
 
 interface ZennArticleCardProps {
   article: ZennArticle;
@@ -32,6 +33,7 @@ export function ZennArticleCard({ article }: ZennArticleCardProps) {
             <MdxHeading as="h2">{article.title}</MdxHeading>
           </Link>
           <div className="flex items-center gap-4 mt-2">
+            <TagList tags={[article.post_type]} />
             <Time date={article.published_at} />
             <span className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-1">
               <Heart className="w-4 h-4" />


### PR DESCRIPTION
- Modified `QiitaArticleCard` to display only the first tag if available, improving clarity.
- Enhanced `ZennArticleCard` to show the post type as a tag, ensuring consistent tag representation across article cards.