### PR TITLE
refactor: Remove like count display from Qiita and Zenn article cards

### DIFF
--- a/components/composites/qiita-article-card/qiita-article-card.tsx
+++ b/components/composites/qiita-article-card/qiita-article-card.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Heart } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Time } from '@/components/elements/time/time';
@@ -41,10 +40,6 @@ export function QiitaArticleCard({ article }: QiitaArticleCardProps) {
           <div className="flex items-center gap-4 mt-2">
             <TagList tags={article.tags.length > 0 ? [article.tags[0].name] : []} />
             <Time date={article.created_at} />
-            <span className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-1">
-              <Heart className="w-4 h-4" />
-              {article.likes_count}
-            </span>
           </div>
         </div>
       </div>

--- a/components/composites/zenn-article-card/zenn-article-card.tsx
+++ b/components/composites/zenn-article-card/zenn-article-card.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Heart } from 'lucide-react';
 import Link from 'next/link';
 import { Time } from '@/components/elements/time/time';
 import { MdxHeading } from '@/components/mdx/heading/heading';
@@ -35,10 +34,6 @@ export function ZennArticleCard({ article }: ZennArticleCardProps) {
           <div className="flex items-center gap-4 mt-2">
             <TagList tags={[article.post_type]} />
             <Time date={article.published_at} />
-            <span className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-1">
-              <Heart className="w-4 h-4" />
-              {article.liked_count}
-            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Eliminated the like count section from both `QiitaArticleCard` and `ZennArticleCard` components to streamline the design and focus on essential information.