### PR TITLE
viewtransitionの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,77 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ebaryo.dev
 
-## Getting Started
+技術的な学びや日々の気づきを共有する技術ブログです。
 
-First, run the development server:
+## 技術スタック
+
+| カテゴリ       | 技術                                           |
+| -------------- | ---------------------------------------------- |
+| フレームワーク | [Next.js](https://nextjs.org) 16 (App Router)  |
+| UI ライブラリ  | [React](https://react.dev) 19                  |
+| 言語           | [TypeScript](https://www.typescriptlang.org) 5 |
+| スタイリング   | [Tailwind CSS](https://tailwindcss.com) 4      |
+| CMS            | [microCMS](https://microcms.io)                |
+
+## 開発ツール
+
+| ツール                                             | 用途           |
+| -------------------------------------------------- | -------------- |
+| [oxlint](https://oxc.rs/docs/guide/usage/linter)   | リンター       |
+| [oxfmt](https://oxc.rs/docs/guide/usage/formatter) | フォーマッター |
+| [Vitest](https://vitest.dev)                       | ユニットテスト |
+| [Playwright](https://playwright.dev)               | E2Eテスト      |
+| [Storybook](https://storybook.js.org)              | UIカタログ     |
+
+## セットアップ
 
 ```bash
+# 依存関係のインストール
+pnpm install
+
+# 環境変数の設定
+cp .env.example .env.local
+# .env.local に必要な環境変数を設定
+
+# 開発サーバーの起動
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+ブラウザで [http://localhost:3000](http://localhost:3000) を開いて確認できます。
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## スクリプト
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| コマンド             | 説明                          |
+| -------------------- | ----------------------------- |
+| `pnpm dev`           | 開発サーバーを起動            |
+| `pnpm build`         | プロダクションビルド          |
+| `pnpm start`         | プロダクションサーバーを起動  |
+| `pnpm lint`          | oxlint でリント実行           |
+| `pnpm lint:fix`      | oxlint で自動修正             |
+| `pnpm format`        | oxfmt でフォーマット          |
+| `pnpm format:check`  | フォーマットチェック          |
+| `pnpm check`         | リント + フォーマットチェック |
+| `pnpm test`          | Vitest でテスト実行           |
+| `pnpm test:unit`     | ユニットテストのみ実行        |
+| `pnpm test:e2e`      | Playwright で E2E テスト実行  |
+| `pnpm test:coverage` | テストカバレッジ計測          |
+| `pnpm storybook`     | Storybook を起動              |
 
-## Learn More
+## ディレクトリ構造
 
-To learn more about Next.js, take a look at the following resources:
+```
+├── app/                # Next.js App Router ページ
+├── components/
+│   ├── atoms/          # 最小単位のUIコンポーネント
+│   ├── molecules/      # 複合コンポーネント
+│   └── organisms/      # 複雑なUIコンポーネント
+├── config/             # 設定ファイル
+└── lib/                # ユーティリティ・ロジック
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## アーキテクチャ
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Container/Presenter パターンを採用しています。
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- **page.tsx** - ルーティング・メタデータ定義
+- **container.tsx** - データ取得・ロジック
+- **presenter.tsx** - UI の描画

--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { Container } from '@/components/organisms';
 import { JsonLd } from '@/components/jsonld/jsonld';
+import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
 import { siteConfig } from '@/config/site';
 import { generateArticleJsonLd } from '@/lib/jsonld';
 import { getPostBySlug } from '@/lib/micro-cms/blog';
@@ -10,6 +11,12 @@ import { BlogPostPresenter } from './presenter';
 interface BlogPostContainerProps {
   slug: string[];
 }
+
+const SuggestEditSection = ({ slug, title }: { slug: string; title: string }) => (
+  <div className="flex justify-end border-b px-6 py-4">
+    <SuggestEditLink slug={slug} title={title} />
+  </div>
+);
 
 export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
   try {
@@ -23,12 +30,16 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
     const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl);
     const content = await renderMicroCMSContent(post.contentHtml);
 
+    const { slug: postSlug, title: postTitle } = post.metadata;
+
     return (
       <>
         <JsonLd data={articleJsonLd} />
         <Container maxWidth="3xl">
           <BlogPostPresenter metadata={post.metadata} />
+          <SuggestEditSection slug={postSlug} title={postTitle} />
           <article className="prose prose-neutral dark:prose-invert max-w-none">{content}</article>
+          <SuggestEditSection slug={postSlug} title={postTitle} />
         </Container>
       </>
     );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { BIZ_UDPGothic } from 'next/font/google';
 import { JsonLd } from '@/components/jsonld/jsonld';
 import type { Metadata } from 'next';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
+import { ViewTransitions } from 'next-view-transitions';
 import { type ReactNode, Suspense } from 'react';
 import { ThemeProvider } from '@/contexts/theme-provider';
 import { generateOrganizationJsonLd } from '@/lib/jsonld';
@@ -84,9 +85,6 @@ const createThemeScript = (): string =>
     .replace(/\s+/g, ' ')
     .trim();
 
-/**
- * ページ構造をラップするコンポーネント
- */
 const PageLayout = ({ children }: { children: ReactNode }) => (
   <>
     <Header />
@@ -95,36 +93,24 @@ const PageLayout = ({ children }: { children: ReactNode }) => (
   </>
 );
 
-/**
- * テーマプロバイダーとページレイアウトをラップするコンポーネント
- */
 const ThemeWrapper = ({ children }: { children: ReactNode }) => (
   <ThemeProvider>
     <PageLayout>{children}</PageLayout>
   </ThemeProvider>
 );
 
-/**
- * Suspenseでラップするコンポーネント
- */
 const SuspenseWrapper = ({ children }: { children: ReactNode }) => (
   <Suspense fallback={null}>
     <ThemeWrapper>{children}</ThemeWrapper>
   </Suspense>
 );
 
-/**
- * アプリケーションのプロバイダーとコンテンツをラップするコンポーネント
- */
 const AppProviders = ({ children }: { children: ReactNode }) => (
   <NuqsAdapter>
     <SuspenseWrapper>{children}</SuspenseWrapper>
   </NuqsAdapter>
 );
 
-/**
- * Body要素の内容をラップするコンポーネント
- */
 const BodyContent = ({ children }: { children: ReactNode }) => {
   const organizationJsonLd = generateOrganizationJsonLd();
 
@@ -144,18 +130,20 @@ const RootLayout = ({
   const themeScript = createThemeScript();
 
   return (
-    <html lang="ja" className="dark" suppressHydrationWarning>
-      <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: themeScript,
-          }}
-        />
-      </head>
-      <body className={`${bizUDPGothic.variable} antialiased font-sans`}>
-        <BodyContent>{children}</BodyContent>
-      </body>
-    </html>
+    <ViewTransitions>
+      <html lang="ja" className="dark" suppressHydrationWarning>
+        <head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: themeScript,
+            }}
+          />
+        </head>
+        <body className={`${bizUDPGothic.variable} antialiased font-sans`}>
+          <BodyContent>{children}</BodyContent>
+        </body>
+      </html>
+    </ViewTransitions>
   );
 };
 

--- a/app/presenter.tsx
+++ b/app/presenter.tsx
@@ -79,6 +79,7 @@ function PostsSection({ posts }: PostsSectionProps) {
             description={post.description}
             eyecatch={post.eyecatch}
             href={`/blog/${post.slug}`}
+            slug={post.slug}
             isExternal={false}
             tags={post.tags}
             title={post.title}

--- a/app/sitemap-page/container.tsx
+++ b/app/sitemap-page/container.tsx
@@ -1,0 +1,13 @@
+import { getAllPostsMetadata } from '@/lib/micro-cms/blog';
+import { logger } from '@/lib/logger';
+import { SitemapPresenter } from './presenter';
+
+export const SitemapContainer = async () => {
+  try {
+    const posts = await getAllPostsMetadata();
+    return <SitemapPresenter posts={posts} />;
+  } catch (error) {
+    logger.error('サイトマップの記事取得に失敗しました', { source: 'sitemap-page' }, error);
+    return <SitemapPresenter posts={[]} />;
+  }
+};

--- a/app/sitemap-page/page.tsx
+++ b/app/sitemap-page/page.tsx
@@ -1,0 +1,15 @@
+import { siteConfig } from '@/config/site';
+import { generateMetadata as generatePageMetadata } from '@/lib/metadata';
+import { SitemapContainer } from './container';
+
+export const revalidate = 3600;
+
+export const metadata = generatePageMetadata({
+  description: `${siteConfig.name}のサイトマップです。すべてのページと記事の一覧を確認できます。`,
+  title: 'サイトマップ',
+  url: `${siteConfig.url}/sitemap-page`,
+});
+
+const SitemapPage = () => <SitemapContainer />;
+
+export default SitemapPage;

--- a/app/sitemap-page/presenter.test.tsx
+++ b/app/sitemap-page/presenter.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { BaseContentMetadata } from '@/lib/content';
+import { SitemapPresenter } from './presenter';
+
+const createMockPost = (overrides: Partial<BaseContentMetadata> = {}): BaseContentMetadata => ({
+  slug: 'test-post',
+  title: 'テスト記事',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-02T00:00:00Z',
+  ...overrides,
+});
+
+describe('SitemapPresenter', () => {
+  it('ページタイトルを表示する', () => {
+    render(<SitemapPresenter posts={[]} />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('サイトマップ');
+  });
+
+  it('静的ページのリンクを表示する', () => {
+    render(<SitemapPresenter posts={[]} />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute('href', '/about');
+    expect(screen.getByRole('link', { name: 'Blog' })).toHaveAttribute('href', '/blog');
+  });
+
+  it('記事リンクを表示する', () => {
+    const posts = [
+      createMockPost({ slug: 'post-1', title: '記事1' }),
+      createMockPost({ slug: 'post-2', title: '記事2' }),
+    ];
+    render(<SitemapPresenter posts={posts} />);
+    expect(screen.getByRole('link', { name: '記事1' })).toHaveAttribute('href', '/blog/post-1');
+    expect(screen.getByRole('link', { name: '記事2' })).toHaveAttribute('href', '/blog/post-2');
+  });
+
+  it('記事がない場合でも静的ページのリンクは表示する', () => {
+    render(<SitemapPresenter posts={[]} />);
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+  });
+});

--- a/app/sitemap-page/presenter.tsx
+++ b/app/sitemap-page/presenter.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { Container } from '@/components/organisms';
+import type { BaseContentMetadata } from '@/lib/content';
+import { Time } from '@/components/atoms/time/time';
+
+interface SitemapPresenterProps {
+  posts: BaseContentMetadata[];
+}
+
+const staticPages = [
+  { href: '/', label: 'Home' },
+  { href: '/about', label: 'About' },
+  { href: '/blog', label: 'Blog' },
+] as const;
+
+export const SitemapPresenter = ({ posts }: SitemapPresenterProps) => (
+  <Container maxWidth="4xl">
+    <div className="space-y-12">
+      <div className="mb-12 text-center space-y-4">
+        <h1 className="font-bold scroll-m-20 text-3xl text-foreground">サイトマップ</h1>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="font-bold scroll-m-20 text-xl border-b pb-2 text-foreground">ページ</h2>
+        <ul className="space-y-2">
+          {staticPages.map((page) => (
+            <li key={page.href}>
+              <Link
+                href={page.href}
+                className="text-primary hover:text-primary/80 transition-colors"
+              >
+                {page.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-bold scroll-m-20 text-xl border-b pb-2 text-foreground">記事</h2>
+        <ul className="space-y-2">
+          {posts.map((post) => (
+            <li key={post.slug} className="flex items-center gap-4">
+              <Link
+                href={`/blog/${post.slug}`}
+                className="text-primary hover:text-primary/80 transition-colors"
+              >
+                {post.title}
+              </Link>
+              <Time date={post.createdAt} />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  </Container>
+);

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,15 +1,3 @@
-/**
- * サイトマップ生成ファイル
- *
- * Next.jsのMetadataRoute.Sitemap型を使用して、サイトの構造を検索エンジンに伝えるための
- * XMLサイトマップを動的に生成します。
- *
- * このファイルはNext.jsの特別なファイル名規則に従っており、`/sitemap.xml`として
- * 自動的に公開されます。検索エンジンクローラーがサイトのページを効率的に発見できるようになります。
- *
- * @see https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
- */
-
 import type { BaseContentMetadata } from '@/lib/content';
 import type { MetadataRoute } from 'next';
 import { getAllPostsMetadata } from '@/lib/micro-cms/blog';
@@ -20,9 +8,6 @@ const PRIORITY_HIGHEST = 1;
 const PRIORITY_HIGH = 0.8;
 const PRIORITY_MEDIUM = 0.7;
 
-/**
- * 静的ページのサイトマップエントリを生成する
- */
 const createStaticPages = (): MetadataRoute.Sitemap => {
   const now = new Date();
   return [
@@ -44,12 +29,15 @@ const createStaticPages = (): MetadataRoute.Sitemap => {
       priority: PRIORITY_HIGH,
       url: `${siteConfig.url}/blog`,
     },
+    {
+      changeFrequency: 'monthly',
+      lastModified: now,
+      priority: PRIORITY_MEDIUM,
+      url: `${siteConfig.url}/sitemap-page`,
+    },
   ];
 };
 
-/**
- * ブログ記事のサイトマップエントリを生成する
- */
 const createBlogPostEntries = (posts: BaseContentMetadata[]): MetadataRoute.Sitemap =>
   posts.map((post) => ({
     changeFrequency: 'weekly',
@@ -58,9 +46,6 @@ const createBlogPostEntries = (posts: BaseContentMetadata[]): MetadataRoute.Site
     url: `${siteConfig.url}/blog/${post.slug}`,
   }));
 
-/**
- * サイトマップを生成する関数
- */
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   const posts = await getAllPostsMetadata();
   const staticPages = createStaticPages();

--- a/components/atoms/back-link/back-link.tsx
+++ b/components/atoms/back-link/back-link.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ArrowLeft } from 'lucide-react';
-import Link from 'next/link';
+import { Link } from 'next-view-transitions';
 
 interface BackLinkProps {
   href: string;

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -5,4 +5,5 @@ export { EmptyState } from './empty-state/empty-state';
 export { MdxBlockquote } from './mdx-blockquote';
 export { MdxH1, MdxH2, MdxH3, MdxH4, MdxH5, MdxH6, MdxHeading } from './mdx-heading';
 export { Pagination } from './pagination/pagination';
+export { SuggestEditLink } from './suggest-edit-link/suggest-edit-link';
 export { TagList } from './tag-list';

--- a/components/molecules/suggest-edit-link/suggest-edit-link.test.tsx
+++ b/components/molecules/suggest-edit-link/suggest-edit-link.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SuggestEditLink } from './suggest-edit-link';
+
+describe('SuggestEditLink', () => {
+  it('リンクを表示する', () => {
+    render(<SuggestEditLink slug="test-post" title="テスト記事" />);
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+  });
+
+  it('GitHubへのリンクを持つ', () => {
+    render(<SuggestEditLink slug="test-post" title="テスト記事" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', expect.stringContaining('github.com'));
+  });
+
+  it('新しいタブで開く', () => {
+    render(<SuggestEditLink slug="test-post" title="テスト記事" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/components/molecules/suggest-edit-link/suggest-edit-link.tsx
+++ b/components/molecules/suggest-edit-link/suggest-edit-link.tsx
@@ -1,0 +1,23 @@
+import { createSuggestEditUrl } from '@/lib/github';
+import { Github } from 'lucide-react';
+
+interface SuggestEditLinkProps {
+  slug: string;
+  title: string;
+}
+
+export const SuggestEditLink = ({ slug, title }: SuggestEditLinkProps) => {
+  const url = createSuggestEditUrl(title, slug);
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <Github className="w-4 h-4" />
+      修正を提案する
+    </a>
+  );
+};

--- a/components/organisms/article-card/article-card.tsx
+++ b/components/organisms/article-card/article-card.tsx
@@ -3,7 +3,7 @@
 import { TagList } from '@/components/molecules/tag-list';
 import { Time } from '@/components/atoms/time/time';
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from 'next-view-transitions';
 import { type CSSProperties, type SyntheticEvent, useState } from 'react';
 
 const ICON_SIZE = 48;
@@ -22,6 +22,7 @@ export interface ArticleCardProps {
   icon?: ArticleCardIconType;
   isExternal?: boolean;
   priority?: boolean;
+  slug?: string;
   tags?: string[];
   title: string;
 }
@@ -95,6 +96,7 @@ export function ArticleCard({
   icon,
   isExternal = false,
   priority = false,
+  slug,
   tags,
   title,
 }: ArticleCardProps) {
@@ -128,7 +130,10 @@ export function ArticleCard({
       />
 
       <div className="relative z-10 flex flex-col">
-        <div className="relative aspect-[16/9] overflow-hidden">
+        <div
+          className="relative aspect-[16/9] overflow-hidden"
+          style={slug ? ({ viewTransitionName: `eyecatch-${slug}` } as CSSProperties) : undefined}
+        >
           <CardBackground eyecatch={eyecatch} priority={priority} onLoad={handleEyecatchLoad} />
           <div className="absolute inset-0 flex items-center justify-center">
             {icon && <CardIcon icon={icon} priority={priority} />}

--- a/components/organisms/post-header/post-header.test.tsx
+++ b/components/organisms/post-header/post-header.test.tsx
@@ -23,9 +23,24 @@ describe('PostHeader', () => {
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
   });
 
-  it('文字数を表示する', () => {
+  it('文字数をカンマ区切りで表示する', () => {
     render(<PostHeader metadata={createMockMetadata({ characterCount: 1500 })} />);
-    expect(screen.getByText('1500 文字')).toBeInTheDocument();
+    expect(screen.getByText('1,500 文字')).toBeInTheDocument();
+  });
+
+  it('999以下の文字数はカンマなしで表示する', () => {
+    render(<PostHeader metadata={createMockMetadata({ characterCount: 999 })} />);
+    expect(screen.getByText('999 文字')).toBeInTheDocument();
+  });
+
+  it('10000以上の文字数にカンマを入れて表示する', () => {
+    render(<PostHeader metadata={createMockMetadata({ characterCount: 10000 })} />);
+    expect(screen.getByText('10,000 文字')).toBeInTheDocument();
+  });
+
+  it('1000000以上の文字数に適切にカンマを入れて表示する', () => {
+    render(<PostHeader metadata={createMockMetadata({ characterCount: 1000000 })} />);
+    expect(screen.getByText('1,000,000 文字')).toBeInTheDocument();
   });
 
   it('説明文がある場合に概要セクションを表示する', () => {

--- a/components/organisms/post-header/post-header.tsx
+++ b/components/organisms/post-header/post-header.tsx
@@ -5,6 +5,7 @@ import { TagList } from '@/components/molecules/tag-list';
 import { Time } from '@/components/atoms/time/time';
 import { Pen } from 'lucide-react';
 import Image from 'next/image';
+import type { CSSProperties } from 'react';
 
 const DEFAULT_EYECATCH_PATH = '/image/default-eyecatch.svg';
 const EYECATCH_WIDTH = 1200;
@@ -17,21 +18,32 @@ interface PostHeaderProps {
 const CharacterCount = ({ count }: { count?: number }) => (
   <span className="text-muted-foreground flex items-center">
     <Pen className="w-4 h-4 mr-1" />
-    {count} 文字
+    {count?.toLocaleString()} 文字
   </span>
 );
 
 const PostEyecatch = ({
   eyecatch,
+  slug,
 }: {
   eyecatch?: { url: string; height?: number; width?: number };
+  slug: string;
 }) => {
   const src = eyecatch?.url ?? DEFAULT_EYECATCH_PATH;
   const width = eyecatch?.width ?? EYECATCH_WIDTH;
   const height = eyecatch?.height ?? EYECATCH_HEIGHT;
 
   return (
-    <Image src={src} alt="" width={width} height={height} className="w-full rounded-lg" priority />
+    <div style={{ viewTransitionName: `eyecatch-${slug}` } as CSSProperties}>
+      <Image
+        src={src}
+        alt=""
+        width={width}
+        height={height}
+        className="w-full rounded-lg"
+        priority
+      />
+    </div>
   );
 };
 
@@ -43,7 +55,7 @@ export const PostHeader = ({ metadata }: PostHeaderProps) => (
       <Time date={metadata.createdAt} />
       <CharacterCount count={metadata.characterCount} />
     </div>
-    <PostEyecatch eyecatch={metadata.eyecatch} />
+    <PostEyecatch eyecatch={metadata.eyecatch} slug={metadata.slug} />
     {metadata.description && (
       <>
         <h2 className="font-bold scroll-m-20 text-xl border-b pb-2 text-foreground">概要</h2>

--- a/components/organisms/post-list/post-list.tsx
+++ b/components/organisms/post-list/post-list.tsx
@@ -21,6 +21,7 @@ export function PostList({ basePath = '/blog', posts }: PostListProps) {
           key={post.slug}
           title={post.title}
           href={`${basePath}/${post.slug}`}
+          slug={post.slug}
           date={post.createdAt}
           tags={post.tags}
           description={post.description}

--- a/config/site.ts
+++ b/config/site.ts
@@ -8,5 +8,6 @@ export const siteConfig = {
   },
   name: 'ebaryo.dev',
   ogImage: '/og-image.jpg',
+  repo: 'ryo-ebata/ebaryo.dev',
   url: process.env.NEXT_PUBLIC_APP_URL || 'https://example.com',
 };

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createSuggestEditUrl } from './github';
+
+describe('createSuggestEditUrl', () => {
+  it('正しいGitHub Issue URLを生成する', () => {
+    const url = createSuggestEditUrl('テスト記事', 'test-post');
+    expect(url).toContain('https://github.com/ryo-ebata/ebaryo.dev/issues/new');
+    expect(url).toContain('title=');
+    expect(url).toContain('body=');
+  });
+
+  it('タイトルにエンコードされた記事タイトルが含まれる', () => {
+    const url = createSuggestEditUrl('テスト記事', 'test-post');
+    const urlObj = new URL(url);
+    const title = urlObj.searchParams.get('title');
+    expect(title).toContain('テスト記事');
+  });
+
+  it('本文にスラッグが含まれる', () => {
+    const url = createSuggestEditUrl('テスト記事', 'test-post');
+    const urlObj = new URL(url);
+    const body = urlObj.searchParams.get('body');
+    expect(body).toContain('test-post');
+  });
+
+  it('特殊文字を含むタイトルを正しくエンコードする', () => {
+    const url = createSuggestEditUrl('React & TypeScript', 'react-ts');
+    expect(url).toContain('https://github.com/ryo-ebata/ebaryo.dev/issues/new');
+  });
+});

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,14 @@
+import { siteConfig } from '@/config/site';
+
+export const createSuggestEditUrl = (title: string, slug: string): string => {
+  const issueTitle = `修正提案: ${title}`;
+  const issueBody = `## 対象記事\n\n- タイトル: ${title}\n- URL: ${siteConfig.url}/blog/${slug}\n\n## 修正内容\n\n<!-- 修正箇所と正しい内容を記載してください -->\n`;
+
+  const params = new URLSearchParams({
+    title: issueTitle,
+    body: issueBody,
+    labels: '修正提案',
+  });
+
+  return `https://github.com/${siteConfig.repo}/issues/new?${params.toString()}`;
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -67,6 +67,7 @@ const nextConfig: NextConfig = {
   /* 実験的な機能 */
   experimental: {
     optimizePackageImports: ['lucide-react', '@tabler/icons-react'],
+    viewTransition: true,
   },
   /* セキュリティヘッダー */
   async headers() {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "microcms-js-sdk": "^3.3.0",
     "next": "16.1.5",
     "next-themes": "^0.4.6",
+    "next-view-transitions": "^0.3.5",
     "nuqs": "^2.8.3",
     "open-graph-scraper": "^6.11.0",
     "react": "19.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next-view-transitions:
+        specifier: ^0.3.5
+        version: 0.3.5(next@16.1.5(@babel/core@7.28.6)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nuqs:
         specifier: ^2.8.3
         version: 2.8.6(next@16.1.5(@babel/core@7.28.6)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -2256,6 +2259,13 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
+  next-view-transitions@0.3.5:
+    resolution: {integrity: sha512-yP8OPNydLmKpmE94hLurLGEzPsUy1uyl9iSv8oxaC2JwhSXTD86SVwk1NMMQT7Ado4kMENDJ7fNBIXHy3GU/Lg==}
+    peerDependencies:
+      next: '>=14.0.0'
+      react: '>=18.2.0 || ^19.0.0'
+      react-dom: '>=18.2.0 || ^19.0.0'
 
   next@16.1.5:
     resolution: {integrity: sha512-f+wE+NSbiQgh3DSAlTaw2FwY5yGdVViAtp8TotNQj4kk4Q8Bh1sC/aL9aH+Rg1YAVn18OYXsRDT7U/079jgP7w==}
@@ -5089,6 +5099,12 @@ snapshots:
 
   next-themes@0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
+  next-view-transitions@0.3.5(next@16.1.5(@babel/core@7.28.6)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      next: 16.1.5(@babel/core@7.28.6)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(dirname),
+      'next-view-transitions': path.resolve(dirname, 'vitest.next-view-transitions-mock.ts'),
       'server-only': path.resolve(dirname, 'vitest.server-only-mock.ts'),
     },
   },

--- a/vitest.next-view-transitions-mock.ts
+++ b/vitest.next-view-transitions-mock.ts
@@ -1,0 +1,4 @@
+import type { ReactNode } from 'react';
+
+export { default as Link } from 'next/link';
+export const ViewTransitions = ({ children }: { children: ReactNode }) => children;


### PR DESCRIPTION
## 📝 変更内容

View Transitionsの導入と、複数の機能追加・改善を行いました。

### View Transitions
- `next-view-transitions` ライブラリを導入し、ページ遷移時のアニメーションを追加
- 記事一覧のアイキャッチ画像と記事詳細ページのアイキャッチ画像間でスムーズなトランジションを実現
- `back-link` と `article-card` の `Link` を `next-view-transitions` の `Link` に置き換え
- `next.config.ts` で `viewTransition: true` を有効化

### サイトマップページ (`/sitemap-page`)
- 静的ページ一覧と全記事一覧を表示するHTMLサイトマップページを新規作成
- Container/Presenter パターンで実装
- `sitemap.xml` にもサイトマップページのエントリを追加
- ユニットテスト追加

### 修正提案リンク (`SuggestEditLink`)
- 記事詳細ページに「修正を提案する」リンクを追加
- クリックするとGitHub Issueが自動作成される（タイトル・本文がプリフィル）
- `lib/github.ts` に URL 生成ロジックを実装
- `config/site.ts` に `repo` フィールドを追加
- ユニットテスト追加

### その他の改善
- 記事ヘッダーの文字数表示をカンマ区切り（`toLocaleString()`）に変更
- README を プロジェクトの実態に合わせて全面的に書き直し
- 不要なJSDocコメントを削除

## 🔗 関連Issue

なし

## 🎯 変更の種類

- [x] ✨ 新機能
- [x] 🎨 UI/UX改善
- [x] 📚 ドキュメント更新

## 🧪 テスト

- [x] ユニットテストを追加/更新

### テスト内容

- `SitemapPresenter`: ページタイトル表示、静的ページリンク、記事リンク表示のテスト
- `SuggestEditLink`: リンク表示、GitHub URLの生成、`target="_blank"` 属性のテスト
- `createSuggestEditUrl`: GitHub Issue URL の生成、パラメータエンコードのテスト
- `PostHeader`: 文字数のカンマ区切り表示テストを追加（999, 1500, 10000, 1000000）
- `next-view-transitions` のVitestモックを追加

## ✅ チェックリスト

- [x] コードがプロジェクトのスタイルガイドに準拠している
- [x] 自己レビューを実施した
- [x] 変更が既存の機能を壊していない
- [x] ビルドが成功することを確認した

## 📋 追加情報

- 新規依存: `next-view-transitions@^0.3.5`
- View Transition の `viewTransitionName` は `eyecatch-{slug}` の命名規則でアイキャッチ画像に付与