### PR TITLE
fix: モバイルヘッダーのロゴ/ナビ折り返しを修正 (#120)

### DIFF
--- a/components/organisms/header/header.tsx
+++ b/components/organisms/header/header.tsx
@@ -14,7 +14,7 @@ const navigationItems = [
 
 const getLinkClassName = (isActive: boolean): string =>
   cn(
-    'text-sm transition-colors',
+    'whitespace-nowrap text-sm transition-colors',
     isActive ? 'text-primary font-semibold' : 'text-muted-foreground hover:text-foreground'
   );
 
@@ -35,7 +35,7 @@ interface NavigationProps {
 }
 
 const Navigation = ({ pathname }: NavigationProps) => (
-  <nav className="flex items-center gap-6">
+  <nav className="flex shrink-0 items-center gap-3 sm:gap-6">
     {navigationItems.map((item) => (
       <NavLink
         key={item.href}
@@ -49,7 +49,10 @@ const Navigation = ({ pathname }: NavigationProps) => (
 );
 
 const SiteLogo = () => (
-  <Link href="/" className="text-xl font-bold text-foreground hover:text-primary transition-colors">
+  <Link
+    href="/"
+    className="shrink-0 whitespace-nowrap text-lg font-bold text-foreground transition-colors hover:text-primary sm:text-xl"
+  >
     {siteConfig.name}
   </Link>
 );
@@ -58,7 +61,7 @@ export const Header = () => {
   const pathname = usePathname();
   return (
     <header className="sticky top-0 z-50 bg-background/80 backdrop-blur ring-1 ring-foreground/10">
-      <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+      <div className="mx-auto flex max-w-4xl items-center justify-between gap-3 px-4 py-4">
         <SiteLogo />
         <Navigation pathname={pathname} />
       </div>


### PR DESCRIPTION
## 概要
モバイル幅(〜390px)でヘッダーのロゴ・ナビが折り返して崩れる問題を修正。

## 変更
- ロゴ・リンクに `whitespace-nowrap`、ロゴ/ナビに `shrink-0` を付与し flex 圧縮による単語内改行を防止
- ロゴを `text-lg`(sm:`text-xl`)、ナビ間隔を `gap-3`(sm:`gap-6`) に縮約
- ロゴ-ナビ間に `gap-3`

3リンク+トグルは 390px に収まるためハンバーガー化は不要と判断（常時表示を維持）。

## 検証
- `pnpm check` 0/0、header.test.tsx 4件 pass、`next build` 成功

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
