### PR TITLE
fix: フッター著作権年を動的レンジ表記に (#122)

### DIFF
--- a/components/organisms/footer/footer.tsx
+++ b/components/organisms/footer/footer.tsx
@@ -10,6 +10,14 @@ const footerLinks = [
   { href: siteConfig.links.twitter, label: 'X' },
 ];
 
+/** サイト開設年。これ以降は現在年までのレンジで著作権表記する。 */
+const FOUNDING_YEAR = 2025;
+
+const getCopyrightYears = (): string => {
+  const currentYear = new Date().getFullYear();
+  return currentYear > FOUNDING_YEAR ? `${FOUNDING_YEAR}–${currentYear}` : `${FOUNDING_YEAR}`;
+};
+
 export const Footer = () => (
   <footer className="bg-background">
     <Separator />
@@ -27,8 +35,8 @@ export const Footer = () => (
           </a>
         ))}
       </nav>
-      <p className="mt-6 text-center text-sm text-muted-foreground">
-        © 2025 {siteConfig.name}. All rights reserved.
+      <p className="mt-6 text-center text-sm text-muted-foreground" suppressHydrationWarning>
+        © {getCopyrightYears()} {siteConfig.name}. All rights reserved.
       </p>
     </div>
   </footer>


### PR DESCRIPTION
固定の「© 2025」を「© 2025–現在年」の動的レンジに変更。検証: check 0/0・footer.test 3件 pass・build 成功。

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)