### PR TITLE
feat: 記事に目次(TOC)を追加 (#123)

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -8,6 +8,8 @@ import { siteConfig } from '@/config/site';
 import { generateArticleJsonLd } from '@/lib/jsonld';
 import { getPostBySlug } from '@/lib/micro-cms/blog';
 import { renderMicroCMSContent } from '@/lib/micro-cms/content-renderer';
+import { extractToc } from '@/lib/micro-cms/extract-toc';
+import { TableOfContents } from '@/components/organisms/table-of-contents/table-of-contents';
 import { BlogPostPresenter } from './presenter';
 
 interface BlogPostContainerProps {
@@ -31,6 +33,7 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
     const postUrl = `${siteConfig.url}/blog/${post.metadata.slug}`;
     const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl);
     const content = await renderMicroCMSContent(post.contentHtml);
+    const toc = extractToc(post.contentHtml);
 
     const { slug: postSlug, title: postTitle } = post.metadata;
 
@@ -42,6 +45,9 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
           <SuggestEditSection slug={postSlug} title={postTitle} />
           <Separator />
           <PromoBlock placement="article-top" />
+          <div className="mx-auto max-w-[42rem]">
+            <TableOfContents items={toc} />
+          </div>
           <article className="prose prose-neutral dark:prose-invert mx-auto max-w-[42rem]">
             {content}
           </article>

--- a/components/organisms/table-of-contents/table-of-contents.tsx
+++ b/components/organisms/table-of-contents/table-of-contents.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import type { TocItem } from '@/lib/micro-cms/extract-toc';
+
+interface TableOfContentsProps {
+  items: TocItem[];
+}
+
+/**
+ * 記事の見出し(h2/h3)から生成する目次。
+ * 折りたたみ可能(details)で、スクロール位置に応じて現在のセクションをハイライトする。
+ */
+export const TableOfContents = ({ items }: TableOfContentsProps) => {
+  const [activeId, setActiveId] = useState('');
+
+  useEffect(() => {
+    const headings = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (headings.length === 0) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '0px 0px -70% 0px', threshold: 0 }
+    );
+
+    headings.forEach((heading) => observer.observe(heading));
+    return () => observer.disconnect();
+  }, [items]);
+
+  if (items.length < 2) {
+    return null;
+  }
+
+  return (
+    <details
+      open
+      className="not-prose group mb-8 overflow-hidden rounded-xl bg-card text-card-foreground shadow-xs ring-1 ring-foreground/10"
+    >
+      <summary className="flex cursor-pointer list-none select-none items-center justify-between gap-2 px-4 py-3 text-sm font-medium">
+        目次
+        <ChevronDown className="size-4 text-muted-foreground transition-transform group-open:rotate-180" />
+      </summary>
+      <nav aria-label="目次" className="px-2 pb-3">
+        <ul className="space-y-0.5 text-sm">
+          {items.map((item) => (
+            <li key={item.id} className={cn(item.depth === 3 && 'ml-4')}>
+              <a
+                href={`#${item.id}`}
+                className={cn(
+                  'block rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground',
+                  activeId === item.id ? 'font-medium text-primary' : 'text-muted-foreground'
+                )}
+              >
+                {item.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </details>
+  );
+};

--- a/lib/micro-cms/extract-toc.test.ts
+++ b/lib/micro-cms/extract-toc.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractToc } from './extract-toc';
+
+describe('extractToc', () => {
+  it('h2/h3 を id・テキスト・深さ付きで抽出する', () => {
+    const html = '<h2>はじめに</h2><p>x</p><h3>背景</h3><h2>まとめ</h2>';
+    expect(extractToc(html)).toEqual([
+      { id: 'はじめに', text: 'はじめに', depth: 2 },
+      { id: '背景', text: '背景', depth: 3 },
+      { id: 'まとめ', text: 'まとめ', depth: 2 },
+    ]);
+  });
+
+  it('h1/h4 以下は対象外', () => {
+    const html = '<h1>title</h1><h2>sec</h2><h4>sub</h4>';
+    expect(extractToc(html).map((i) => i.text)).toEqual(['sec']);
+  });
+
+  it('重複見出しでも id が一意になり本文アンカーと整合する', () => {
+    const items = extractToc('<h2>Note</h2><h2>Note</h2>');
+    expect(items.map((i) => i.id)).toEqual(['note', 'note-1']);
+  });
+
+  it('見出しが無ければ空配列', () => {
+    expect(extractToc('<p>本文のみ</p>')).toEqual([]);
+  });
+});

--- a/lib/micro-cms/extract-toc.ts
+++ b/lib/micro-cms/extract-toc.ts
@@ -1,0 +1,42 @@
+import type { Element, Root } from 'hast';
+import rehypeParse from 'rehype-parse';
+import rehypeSlug from 'rehype-slug';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
+
+export interface TocItem {
+  id: string;
+  text: string;
+  depth: 2 | 3;
+}
+
+/** 見出し要素配下のテキストを連結して取り出す。 */
+const getHeadingText = (node: Element): string => {
+  let text = '';
+  visit(node, 'text', (textNode) => {
+    text += textNode.value;
+  });
+  return text.trim();
+};
+
+/**
+ * 記事HTMLから h2/h3 見出しの目次（id・テキスト・深さ）を抽出する。
+ * content-renderer と同じ rehype-slug を使うため、生成される id は本文側のアンカーと一致する。
+ */
+export const extractToc = (html: string): TocItem[] => {
+  const processor = unified().use(rehypeParse, { fragment: true }).use(rehypeSlug);
+  const tree = processor.runSync(processor.parse(html)) as Root;
+
+  const items: TocItem[] = [];
+  visit(tree, 'element', (node) => {
+    if (node.tagName !== 'h2' && node.tagName !== 'h3') {
+      return;
+    }
+    const id = typeof node.properties?.id === 'string' ? node.properties.id : '';
+    const text = getHeadingText(node);
+    if (id && text) {
+      items.push({ id, text, depth: node.tagName === 'h2' ? 2 : 3 });
+    }
+  });
+  return items;
+};


### PR DESCRIPTION
## 概要
記事詳細に見出し(h2/h3)ベースの目次を追加。

## 変更
- `lib/micro-cms/extract-toc.ts`: 本文と同じ rehype-slug で h2/h3 を抽出(id がアンカーと一致)
- `components/organisms/table-of-contents`: 折りたたみ目次カード + スクロール連動ハイライト(IntersectionObserver)
- 記事本文冒頭に配置(見出し2件未満は非表示)

## 補足
デスクトップ sticky サイドバーは現行の中央1カラムレイアウトを大きく変更するため見送り、まず全幅の折りたたみ版で導入(拡張余地)。

## 検証
- `pnpm check` 0/0、tsc クリーン、micro-cms 49件 + extract-toc 4件 pass、`next build` 成功

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)