### PR TITLE
fix: サイトURLのフォールバックを実ドメインに修正 (#126)

### DIFF
--- a/config/site.ts
+++ b/config/site.ts
@@ -8,5 +8,5 @@ export const siteConfig = {
   },
   name: 'ebaryo.dev',
   repo: 'ryo-ebata/ebaryo.dev',
-  url: process.env.NEXT_PUBLIC_APP_URL || 'https://example.com',
+  url: process.env.NEXT_PUBLIC_APP_URL || 'https://ebaryo.dev',
 };


### PR DESCRIPTION
## 概要
`NEXT_PUBLIC_APP_URL` 未設定時のフォールバックが `https://example.com` で、og:url・sitemap・rss・JSON-LD・metadata 等が存在しないドメインを指す重大不具合を修正。

## 変更
- `config/site.ts`: フォールバックを `https://ebaryo.dev` に

## 補足（インフラ・別途推奨）
恒久的には Vercel の本番/Preview 環境変数に `NEXT_PUBLIC_APP_URL=https://ebaryo.dev` を設定するのが望ましい。本修正は env 未設定でも壊れないための保険。

## 検証
- `pnpm check` 0/0、unit 233件 pass、`next build` 成功

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)