### PR TITLE
feat: 全ページに canonical と metadataBase を設定 (#127)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,10 @@ const bizUDPGothic = BIZ_UDPGothic({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteConfig.url),
+  alternates: {
+    canonical: siteConfig.url,
+  },
   description: siteConfig.description,
   openGraph: {
     description: siteConfig.description,

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -61,6 +61,9 @@ export const generateMetadata = (params: MetadataParams): Metadata => {
   const imageAltText = imageAlt || title;
 
   const baseMetadata: Metadata = {
+    alternates: {
+      canonical: pageUrl,
+    },
     description,
     openGraph: {
       description,


### PR DESCRIPTION
## 概要
canonical URL と metadataBase 未設定の問題を解消。

## 変更
- `lib/metadata.ts`: `alternates.canonical = pageUrl` を追加(各ページ/記事が自身の絶対URLを canonical 出力。全ページが url を渡済み)
- `app/layout.tsx`: `metadataBase = new URL(siteConfig.url)` を設定

## 結果
- 全ページに正しいドメインの canonical が出力
- OG画像等の相対URLが実ドメインで解決され **ビルドの metadataBase 警告が解消**(確認済み)

## 検証
- `pnpm check` 0/0、metadata 10件 pass、`next build` 成功・警告消滅

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)