### PR TITLE
feat: robots.ts を追加 (#128)

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+import { siteConfig } from '@/config/site';
+
+const robots = (): MetadataRoute.Robots => ({
+  rules: {
+    userAgent: '*',
+    allow: '/',
+    disallow: ['/api/'],
+  },
+  sitemap: `${siteConfig.url}/sitemap.xml`,
+  host: siteConfig.url,
+});
+
+export default robots;


### PR DESCRIPTION
app/robots.ts を追加(MetadataRoute.Robots)。siteConfig.url 流用、/api/ disallow、Sitemap 参照行を出力。検証: check 0/0・build で /robots.txt 生成確認。

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)