### PR TITLE
feat: head に RSS 自動検出 link を追加 (#129)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,9 @@ export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.url),
   alternates: {
     canonical: siteConfig.url,
+    types: {
+      'application/rss+xml': `${siteConfig.url}/rss.xml`,
+    },
   },
   description: siteConfig.description,
   openGraph: {

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -63,6 +63,9 @@ export const generateMetadata = (params: MetadataParams): Metadata => {
   const baseMetadata: Metadata = {
     alternates: {
       canonical: pageUrl,
+      types: {
+        'application/rss+xml': `${siteConfig.url}/rss.xml`,
+      },
     },
     description,
     openGraph: {


### PR DESCRIPTION
`alternates.types` に `application/rss+xml` を追加し `<link rel=alternate>` を出力。

各ページは generateMetadata で alternates を上書きするため、**layout と generateMetadata の両方**に追加して全ページで autodiscovery を有効化(issue 提案の layout のみだとページ側で消えるため)。

検証: check 0/0・metadata 10件 pass・build 成功。

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)