### PR TITLE
feat: 記事に BreadcrumbList 構造化データとパンくずUIを追加 (#130)

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -3,9 +3,10 @@ import { Separator } from '@/components/atoms/separator';
 import { Container } from '@/components/organisms';
 import { PromoBlock } from '@/components/organisms/promo-block/promo-block';
 import { JsonLd } from '@/components/jsonld/jsonld';
+import { Breadcrumb } from '@/components/molecules/breadcrumb/breadcrumb';
 import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
 import { siteConfig } from '@/config/site';
-import { generateArticleJsonLd } from '@/lib/jsonld';
+import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
 import { getPostBySlug } from '@/lib/micro-cms/blog';
 import { renderMicroCMSContent } from '@/lib/micro-cms/content-renderer';
 import { extractToc } from '@/lib/micro-cms/extract-toc';
@@ -37,10 +38,23 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
 
     const { slug: postSlug, title: postTitle } = post.metadata;
 
+    const breadcrumbItems = [
+      { name: 'Home', href: '/' },
+      { name: 'ブログ', href: '/blog' },
+      { name: postTitle },
+    ];
+    const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+      { name: 'Home', url: siteConfig.url },
+      { name: 'ブログ', url: `${siteConfig.url}/blog` },
+      { name: postTitle, url: postUrl },
+    ]);
+
     return (
       <>
         <JsonLd data={articleJsonLd} />
+        <JsonLd data={breadcrumbJsonLd} />
         <Container maxWidth="3xl">
+          <Breadcrumb items={breadcrumbItems} />
           <BlogPostPresenter metadata={post.metadata} />
           <SuggestEditSection slug={postSlug} title={postTitle} />
           <Separator />

--- a/components/molecules/breadcrumb/breadcrumb.tsx
+++ b/components/molecules/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,40 @@
+import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+
+import { cn } from '@/lib/utils';
+
+export interface BreadcrumbItem {
+  name: string;
+  href?: string;
+}
+
+/**
+ * 視覚的パンくずリスト。最後の項目を現在地として強調し、それ以外はリンクにする。
+ * BreadcrumbList 構造化データ(lib/jsonld の generateBreadcrumbJsonLd)と表示を揃える。
+ */
+export const Breadcrumb = ({ items }: { items: BreadcrumbItem[] }) => (
+  <nav aria-label="パンくずリスト" className="not-prose">
+    <ol className="flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <li key={item.name} className="flex min-w-0 items-center gap-1.5">
+            {item.href && !isLast ? (
+              <Link href={item.href} className="transition-colors hover:text-foreground">
+                {item.name}
+              </Link>
+            ) : (
+              <span
+                className={cn('truncate', isLast && 'text-foreground')}
+                aria-current={isLast ? 'page' : undefined}
+              >
+                {item.name}
+              </span>
+            )}
+            {!isLast && <ChevronRight aria-hidden className="size-3.5 shrink-0" />}
+          </li>
+        );
+      })}
+    </ol>
+  </nav>
+);

--- a/lib/jsonld.test.ts
+++ b/lib/jsonld.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { BaseContentMetadata } from './content';
-import { generateArticleJsonLd, generateOrganizationJsonLd, generateWebSiteJsonLd } from './jsonld';
+import {
+  generateArticleJsonLd,
+  generateBreadcrumbJsonLd,
+  generateOrganizationJsonLd,
+  generateWebSiteJsonLd,
+} from './jsonld';
 
 const createMockMetadata = (overrides: Partial<BaseContentMetadata> = {}): BaseContentMetadata => ({
   slug: 'test-slug',
@@ -109,5 +114,27 @@ describe('generateOrganizationJsonLd', () => {
 
     expect(result.sameAs).toBeDefined();
     expect(Array.isArray(result.sameAs)).toBe(true);
+  });
+});
+
+describe('generateBreadcrumbJsonLd', () => {
+  it('BreadcrumbList を position 付き itemListElement で生成する', () => {
+    const result = generateBreadcrumbJsonLd([
+      { name: 'Home', url: 'https://ebaryo.dev' },
+      { name: 'ブログ', url: 'https://ebaryo.dev/blog' },
+      { name: 'テスト記事', url: 'https://ebaryo.dev/blog/test' },
+    ]);
+
+    expect(result['@type']).toBe('BreadcrumbList');
+    expect(result.itemListElement).toEqual([
+      { '@type': 'ListItem', item: 'https://ebaryo.dev', name: 'Home', position: 1 },
+      { '@type': 'ListItem', item: 'https://ebaryo.dev/blog', name: 'ブログ', position: 2 },
+      {
+        '@type': 'ListItem',
+        item: 'https://ebaryo.dev/blog/test',
+        name: 'テスト記事',
+        position: 3,
+      },
+    ]);
   });
 });

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -96,3 +96,19 @@ export const generateOrganizationJsonLd = (): Record<string, unknown> => {
 
   return organization;
 };
+
+/**
+ * パンくず（BreadcrumbList）用のJSON-LDスキーマを生成
+ */
+export const generateBreadcrumbJsonLd = (
+  items: { name: string; url: string }[]
+): Record<string, unknown> => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: items.map((item, index) => ({
+    '@type': 'ListItem',
+    item: item.url,
+    name: item.name,
+    position: index + 1,
+  })),
+});


### PR DESCRIPTION
## 変更
- `lib/jsonld.ts`: `generateBreadcrumbJsonLd`(Home>ブログ>記事 を position 付きで生成)
- `components/molecules/breadcrumb`: 視覚的パンくず(現在地を aria-current で強調)
- 記事コンテナで `<JsonLd>` 並設 + パンくず表示
- `lib/jsonld.test` に BreadcrumbList テスト追加

階層は Home>ブログ>記事(現データに即した3階層)。検証: check 0/0・jsonld 12件 pass・build 成功。

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)