### PR TITLE
feat: 記事ごとの動的OGP画像を追加 (#131)

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -41,9 +41,14 @@ const buildMetadata = (post: MicroCMSContentData): Metadata => {
   const postUrl = `${siteConfig.url}/blog/${post.metadata.slug}`;
   const description = getDescription(post.metadata.description);
 
+  /* eyecatch があればそれを OG に、無ければ記事タイトル焼き込みの動的 OG を使う */
+  const ogImage =
+    post.metadata.eyecatch?.url ??
+    `${siteConfig.url}/og?title=${encodeURIComponent(post.metadata.title)}`;
+
   return generatePageMetadata({
     description,
-    image: post.metadata.eyecatch?.url,
+    image: ogImage,
     imageAlt: post.metadata.title,
     modifiedTime: post.metadata.updatedAt,
     publishedTime: post.metadata.createdAt,

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -1,0 +1,31 @@
+import { ImageResponse } from 'next/og';
+import type { NextRequest } from 'next/server';
+import { siteConfig } from '@/config/site';
+import { loadOgFont } from '@/lib/og/og-font';
+import { OgImageElement } from '@/lib/og/og-image-element';
+import { OG_IMAGE_SIZE } from '@/lib/og/og-params';
+
+export const contentType = 'image/png';
+
+/**
+ * 記事タイトルを焼き込んだ動的OG画像を生成する共通エンドポイント。
+ * catch-all ルート([...slug])配下には opengraph-image を置けない(Next.js 制約)ため、
+ * クエリ ?title= で生成する。eyecatch 未設定の記事の OG として metadata から参照する。
+ */
+export const GET = async (request: NextRequest) => {
+  const title = request.nextUrl.searchParams.get('title') ?? siteConfig.name;
+  const subtitle = request.nextUrl.searchParams.get('subtitle') ?? siteConfig.name;
+  const fontData = await loadOgFont();
+
+  return new ImageResponse(<OgImageElement subtitle={subtitle} title={title} />, {
+    ...OG_IMAGE_SIZE,
+    fonts: [
+      {
+        data: fontData,
+        name: 'Noto Sans JP',
+        style: 'normal',
+        weight: 700,
+      },
+    ],
+  });
+};


### PR DESCRIPTION
## 概要
eyecatch 未設定の記事に、記事タイトル焼き込みの動的OG画像を生成。

## 変更
- `app/og/route.tsx`: `?title=` で `OgImageElement` を `ImageResponse` 化する共通OGエンドポイント
- `app/blog/[...slug]/page.tsx`: OG画像を `eyecatch ?? /og?title=記事タイトル` に(eyecatch優先のハイブリッド)

## 補足(設計上の判断)
Issue 提案の `app/blog/[...slug]/opengraph-image.tsx` は **Next.js 制約「catch-all must be the last part of the URL」によりビルド不可**だったため、業界標準のクエリ式OGエンドポイント `/og?title=` に切替。`/api/` は #128 で robots disallow 済みのため `/og` を採用。生成は CDN キャッシュ前提のオンデマンド。

## 検証
- `pnpm check` 0/0、`next build` 成功(/og ルート生成)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)