### PR TITLE
feat: 記事末に関連記事(Jaccard類似度)セクションを追加 (#132)

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -7,9 +7,11 @@ import { Breadcrumb } from '@/components/molecules/breadcrumb/breadcrumb';
 import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
 import { siteConfig } from '@/config/site';
 import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
-import { getPostBySlug } from '@/lib/micro-cms/blog';
+import { getAllPostsMetadata, getPostBySlug } from '@/lib/micro-cms/blog';
 import { renderMicroCMSContent } from '@/lib/micro-cms/content-renderer';
 import { extractToc } from '@/lib/micro-cms/extract-toc';
+import { getRelatedPosts } from '@/lib/related';
+import { PostList } from '@/components/organisms/post-list/post-list';
 import { TableOfContents } from '@/components/organisms/table-of-contents/table-of-contents';
 import { BlogPostPresenter } from './presenter';
 
@@ -35,6 +37,7 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
     const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl);
     const content = await renderMicroCMSContent(post.contentHtml);
     const toc = extractToc(post.contentHtml);
+    const relatedPosts = getRelatedPosts(post.metadata, await getAllPostsMetadata(), 3);
 
     const { slug: postSlug, title: postTitle } = post.metadata;
 
@@ -66,6 +69,12 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
             {content}
           </article>
           <PromoBlock placement="article-bottom" />
+          {relatedPosts.length > 0 && (
+            <section className="mt-12">
+              <h2 className="mb-5 text-lg font-semibold text-foreground">関連記事</h2>
+              <PostList posts={relatedPosts} />
+            </section>
+          )}
           <Separator />
           <SuggestEditSection slug={postSlug} title={postTitle} />
         </Container>

--- a/lib/related.test.ts
+++ b/lib/related.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BaseContentMetadata } from './content';
+import { getRelatedPosts } from './related';
+
+const post = (
+  slug: string,
+  tags: string[],
+  createdAt = '2025-01-01T00:00:00Z'
+): BaseContentMetadata => ({
+  slug,
+  title: slug,
+  createdAt,
+  tags,
+});
+
+describe('getRelatedPosts', () => {
+  const current = post('current', ['react', 'typescript', 'next']);
+
+  it('共通タグが多い順に上位を返し、自分自身は除外する', () => {
+    const all = [
+      current,
+      post('a', ['react', 'typescript']),
+      post('b', ['react']),
+      post('c', ['go']),
+    ];
+    const result = getRelatedPosts(current, all, 3).map((p) => p.slug);
+    expect(result[0]).toBe('a');
+    expect(result[1]).toBe('b');
+    expect(result).not.toContain('current');
+  });
+
+  it('limit 件に制限する', () => {
+    const all = [current, post('a', ['react']), post('b', ['next']), post('c', ['typescript'])];
+    expect(getRelatedPosts(current, all, 2)).toHaveLength(2);
+  });
+
+  it('同点は新しい順(createdAt 降順)で安定ソート', () => {
+    const all = [
+      current,
+      post('old', ['react'], '2025-01-01T00:00:00Z'),
+      post('new', ['react'], '2025-06-01T00:00:00Z'),
+    ];
+    expect(getRelatedPosts(current, all, 2).map((p) => p.slug)).toEqual(['new', 'old']);
+  });
+
+  it('共通タグが無ければ最新記事で補填する', () => {
+    const all = [
+      current,
+      post('x', ['go'], '2025-03-01T00:00:00Z'),
+      post('y', ['rust'], '2025-05-01T00:00:00Z'),
+    ];
+    expect(getRelatedPosts(current, all, 2).map((p) => p.slug)).toEqual(['y', 'x']);
+  });
+});

--- a/lib/related.ts
+++ b/lib/related.ts
@@ -1,0 +1,54 @@
+import type { BaseContentMetadata } from '@/lib/content';
+
+/** 2つのタグ集合の Jaccard 類似度 (|共通| / |和集合|) */
+const jaccardSimilarity = (a: string[], b: string[]): number => {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size === 0 || setB.size === 0) {
+    return 0;
+  }
+  let intersection = 0;
+  for (const tag of setA) {
+    if (setB.has(tag)) {
+      intersection += 1;
+    }
+  }
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 0 : intersection / union;
+};
+
+/**
+ * タグの Jaccard 類似度で関連記事を上位 limit 件返す純関数。
+ * - 自分自身は除外
+ * - 同点は新しい順(createdAt 降順)で安定ソート
+ * - 共通タグのある記事が足りない場合は最新記事で補填し、空セクションを避ける
+ */
+export const getRelatedPosts = (
+  current: BaseContentMetadata,
+  allPosts: BaseContentMetadata[],
+  limit = 3
+): BaseContentMetadata[] => {
+  const candidates = allPosts.filter((post) => post.slug !== current.slug);
+  const currentTags = current.tags ?? [];
+
+  const scored = candidates
+    .map((post) => ({ post, score: jaccardSimilarity(currentTags, post.tags ?? []) }))
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return b.post.createdAt.localeCompare(a.post.createdAt);
+    });
+
+  const related = scored.filter((entry) => entry.score > 0).map((entry) => entry.post);
+  if (related.length >= limit) {
+    return related.slice(0, limit);
+  }
+
+  const usedSlugs = new Set([current.slug, ...related.map((post) => post.slug)]);
+  const fillers = candidates
+    .filter((post) => !usedSlugs.has(post.slug))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+  return [...related, ...fillers].slice(0, limit);
+};


### PR DESCRIPTION
## 変更
- `lib/related.ts`: タグの Jaccard 類似度で関連記事上位N件を返す純関数(自分除外/同点は createdAt 降順/共通タグ不足時は最新記事で補填し空セクション回避)
- 記事末(article-bottom 付近)に「関連記事」セクションを既存 PostList で表示
- `lib/related.test`: スコア順/自己除外/limit/補填の単体テスト

検証: check 0/0・related 4件 pass・build 成功。

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)