### PR TITLE
feat: 記事ヘッダーに読了時間を追加 (#133)

### DIFF
--- a/components/organisms/post-header/post-header.tsx
+++ b/components/organisms/post-header/post-header.tsx
@@ -4,7 +4,8 @@ import type { BaseContentMetadata } from '@/lib/content';
 import { TagList } from '@/components/molecules/tag-list';
 import { Separator } from '@/components/atoms/separator';
 import { Time } from '@/components/atoms/time/time';
-import { Pen } from 'lucide-react';
+import { getReadingTimeMinutes } from '@/lib/reading-time';
+import { Clock, Pen } from 'lucide-react';
 import Image from 'next/image';
 import type { CSSProperties } from 'react';
 
@@ -22,6 +23,17 @@ const CharacterCount = ({ count }: { count?: number }) => (
     {count?.toLocaleString()} 文字
   </span>
 );
+
+const ReadingTime = ({ count }: { count?: number }) => {
+  if (count === undefined) {
+    return null;
+  }
+  return (
+    <span className="flex items-center gap-1 text-sm text-muted-foreground">
+      <Clock className="size-4" />約{getReadingTimeMinutes(count)}分で読める
+    </span>
+  );
+};
 
 const PostEyecatch = ({
   eyecatch,
@@ -55,6 +67,7 @@ export const PostHeader = ({ metadata }: PostHeaderProps) => (
       {metadata.tags && <TagList tags={metadata.tags} />}
       <Time date={metadata.createdAt} />
       <CharacterCount count={metadata.characterCount} />
+      <ReadingTime count={metadata.characterCount} />
     </div>
     <PostEyecatch eyecatch={metadata.eyecatch} slug={metadata.slug} />
     {metadata.description && (

--- a/lib/reading-time.test.ts
+++ b/lib/reading-time.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { getReadingTimeMinutes, READING_CHARS_PER_MINUTE } from './reading-time';
+
+describe('getReadingTimeMinutes', () => {
+  it('0文字でも最低1分を返す', () => {
+    expect(getReadingTimeMinutes(0)).toBe(1);
+  });
+
+  it('1分未満は1分に切り上げる', () => {
+    expect(getReadingTimeMinutes(1)).toBe(1);
+    expect(getReadingTimeMinutes(READING_CHARS_PER_MINUTE)).toBe(1);
+  });
+
+  it('端数は切り上げる', () => {
+    expect(getReadingTimeMinutes(READING_CHARS_PER_MINUTE + 1)).toBe(2);
+    expect(getReadingTimeMinutes(READING_CHARS_PER_MINUTE * 3)).toBe(3);
+    expect(getReadingTimeMinutes(READING_CHARS_PER_MINUTE * 3 + 1)).toBe(4);
+  });
+});

--- a/lib/reading-time.ts
+++ b/lib/reading-time.ts
@@ -1,0 +1,12 @@
+/** 日本語本文(コードブロック除外済み)の基準読書速度。字/分 */
+export const READING_CHARS_PER_MINUTE = 500;
+
+/**
+ * 文字数から読了時間(分)を算出する。最低 1 分に丸める。
+ */
+export const getReadingTimeMinutes = (characterCount: number): number => {
+  if (characterCount <= 0) {
+    return 1;
+  }
+  return Math.max(1, Math.ceil(characterCount / READING_CHARS_PER_MINUTE));
+};


### PR DESCRIPTION
characterCount から読了時間(500字/分・最低1分・切り上げ)を算出し、文字数の隣に「約N分で読める」を表示。検証: check 0/0・reading-time+post-header 11件 pass・build 成功。

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)