### PR TITLE
feat: 記事ページに読書進捗バーを追加 (#134)

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -4,6 +4,7 @@ import { Container } from '@/components/organisms';
 import { PromoBlock } from '@/components/organisms/promo-block/promo-block';
 import { JsonLd } from '@/components/jsonld/jsonld';
 import { Breadcrumb } from '@/components/molecules/breadcrumb/breadcrumb';
+import { ReadingProgress } from '@/components/molecules/reading-progress/reading-progress';
 import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
 import { siteConfig } from '@/config/site';
 import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
@@ -56,6 +57,7 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
       <>
         <JsonLd data={articleJsonLd} />
         <JsonLd data={breadcrumbJsonLd} />
+        <ReadingProgress />
         <Container maxWidth="3xl">
           <Breadcrumb items={breadcrumbItems} />
           <BlogPostPresenter metadata={post.metadata} />

--- a/components/molecules/reading-progress/reading-progress.tsx
+++ b/components/molecules/reading-progress/reading-progress.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface ReadingProgressProps {
+  /** 進捗の基準にする要素のセレクタ(既定: 記事本文 article)。 */
+  targetSelector?: string;
+}
+
+/**
+ * ページ上部固定の読書進捗バー。基準要素(記事本文)のスクロール量で 0→100% に変化する。
+ * prefers-reduced-motion 時は非表示(motion-reduce:hidden)。
+ */
+export const ReadingProgress = ({ targetSelector = 'article' }: ReadingProgressProps) => {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const target = document.querySelector<HTMLElement>(targetSelector);
+    if (!target) {
+      return;
+    }
+
+    const update = () => {
+      const start = target.offsetTop;
+      const end = start + target.offsetHeight - window.innerHeight;
+      const total = end - start;
+      const value = total <= 0 ? 1 : (window.scrollY - start) / total;
+      setProgress(Math.min(1, Math.max(0, value)));
+    };
+
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, [targetSelector]);
+
+  return (
+    <div aria-hidden className="fixed inset-x-0 top-0 z-50 h-1 motion-reduce:hidden">
+      <div
+        className="h-full bg-primary transition-[width] duration-75 ease-out"
+        style={{ width: `${progress * 100}%` }}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
本文(article)基準のスクロール進捗を上部固定バーで可視化(方針B)。テラコッタ色、prefers-reduced-motion 時は非表示、記事ページ専用。検証: check 0/0・build 成功。

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)