### PR TITLE
feat: 記事にシェアボタン(X/はてブ/リンクコピー)を追加 (#135)

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -5,6 +5,7 @@ import { PromoBlock } from '@/components/organisms/promo-block/promo-block';
 import { JsonLd } from '@/components/jsonld/jsonld';
 import { Breadcrumb } from '@/components/molecules/breadcrumb/breadcrumb';
 import { ReadingProgress } from '@/components/molecules/reading-progress/reading-progress';
+import { ShareButtons } from '@/components/molecules/share-buttons/share-buttons';
 import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
 import { siteConfig } from '@/config/site';
 import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
@@ -70,6 +71,9 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
           <article className="prose prose-neutral dark:prose-invert mx-auto max-w-[42rem]">
             {content}
           </article>
+          <div className="mx-auto mt-6 max-w-[42rem]">
+            <ShareButtons url={postUrl} title={postTitle} />
+          </div>
           <PromoBlock placement="article-bottom" />
           {relatedPosts.length > 0 && (
             <section className="mt-12">

--- a/components/molecules/share-buttons/share-buttons.tsx
+++ b/components/molecules/share-buttons/share-buttons.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { IconBrandX } from '@tabler/icons-react';
+import { Bookmark, Check, Link2 } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/atoms/button';
+import { siteConfig } from '@/config/site';
+
+const COPY_FEEDBACK_MS = 2000;
+
+const getXShareUrl = (url: string, title: string): string => {
+  const via = siteConfig.links.twitter.split('/').pop() ?? '';
+  const params = new URLSearchParams({ text: title, url });
+  if (via) {
+    params.set('via', via);
+  }
+  return `https://twitter.com/intent/tweet?${params.toString()}`;
+};
+
+const getHatenaUrl = (url: string): string =>
+  `https://b.hatena.ne.jp/entry/s/${url.replace(/^https?:\/\//, '')}`;
+
+export const ShareButtons = ({ url, title }: { url: string; title: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      /* クリップボード非対応/権限拒否時は何もしない */
+    }
+  };
+
+  return (
+    <div className="not-prose flex flex-wrap items-center gap-2">
+      <span className="text-sm text-muted-foreground">シェア:</span>
+      <Button
+        variant="outline"
+        size="sm"
+        render={<a href={getXShareUrl(url, title)} target="_blank" rel="noopener noreferrer" />}
+      >
+        <IconBrandX className="size-4" />X
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        render={<a href={getHatenaUrl(url)} target="_blank" rel="noopener noreferrer" />}
+      >
+        <Bookmark className="size-4" />
+        はてブ
+      </Button>
+      <Button variant="outline" size="sm" onClick={handleCopy}>
+        {copied ? <Check className="size-4" /> : <Link2 className="size-4" />}
+        {copied ? 'コピーしました' : 'リンクをコピー'}
+      </Button>
+    </div>
+  );
+};


### PR DESCRIPTION
外部SDKなしで intent URL を自前生成。X / はてなブックマーク / Clipboard リンクコピー(コピー後チェック)。Button(outline,sm)+lucide/tabler アイコンで統一し記事末尾に配置。検証: check 0/0・build 成功。

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)