### PR TITLE
feat: ニュースレター購読フォームを追加 (#137)

### DIFF
--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+
+const BUTTONDOWN_ENDPOINT = 'https://api.buttondown.email/v1/subscribers';
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const HTTP_BAD_REQUEST = 400;
+const HTTP_SERVICE_UNAVAILABLE = 503;
+const HTTP_BAD_GATEWAY = 502;
+
+interface SubscribeBody {
+  email?: string;
+  /** ハニーポット(bot が埋めるダミー項目)。値が入っていれば bot とみなす。 */
+  website?: string;
+}
+
+/**
+ * ニュースレター購読プロキシ。サーバ専用の BUTTONDOWN_API_KEY を用いて購読登録する。
+ * キーが未設定なら 503。ハニーポット検出時は成功を装って黙殺する。
+ */
+export const POST = async (request: Request) => {
+  const apiKey = process.env.BUTTONDOWN_API_KEY ?? '';
+  if (!apiKey) {
+    return NextResponse.json(
+      { ok: false, message: '購読は現在利用できません。' },
+      { status: HTTP_SERVICE_UNAVAILABLE }
+    );
+  }
+
+  let body: SubscribeBody;
+  try {
+    body = (await request.json()) as SubscribeBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, message: '不正なリクエストです。' },
+      { status: HTTP_BAD_REQUEST }
+    );
+  }
+
+  /* ハニーポットに値があれば bot とみなし、成功を装って黙殺 */
+  if (body.website) {
+    return NextResponse.json({ ok: true, message: '登録しました。' });
+  }
+
+  const email = (body.email ?? '').trim();
+  if (!EMAIL_PATTERN.test(email)) {
+    return NextResponse.json(
+      { ok: false, message: 'メールアドレスの形式が正しくありません。' },
+      { status: HTTP_BAD_REQUEST }
+    );
+  }
+
+  try {
+    const response = await fetch(BUTTONDOWN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Token ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email_address: email }),
+    });
+
+    if (response.ok) {
+      return NextResponse.json({
+        ok: true,
+        message: '登録しました。確認メールをご確認ください。',
+      });
+    }
+    /* 既に登録済み等(プロバイダが 400 を返す)はユーザー向けに穏当な文言で返す */
+    if (response.status === HTTP_BAD_REQUEST) {
+      return NextResponse.json({
+        ok: false,
+        message: 'すでに登録済みか、登録できませんでした。',
+      });
+    }
+    return NextResponse.json(
+      { ok: false, message: '登録に失敗しました。時間をおいて再度お試しください。' },
+      { status: HTTP_BAD_GATEWAY }
+    );
+  } catch {
+    return NextResponse.json(
+      { ok: false, message: '通信エラーが発生しました。' },
+      { status: HTTP_BAD_GATEWAY }
+    );
+  }
+};

--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -7,6 +7,8 @@ import { Breadcrumb } from '@/components/molecules/breadcrumb/breadcrumb';
 import { ReadingProgress } from '@/components/molecules/reading-progress/reading-progress';
 import { ShareButtons } from '@/components/molecules/share-buttons/share-buttons';
 import { GiscusComments } from '@/components/organisms/comments/giscus-comments';
+import { NewsletterForm } from '@/components/molecules/newsletter-form/newsletter-form';
+import { isNewsletterEnabled } from '@/config/newsletter';
 import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
 import { siteConfig } from '@/config/site';
 import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
@@ -81,6 +83,11 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
               <h2 className="mb-5 text-lg font-semibold text-foreground">関連記事</h2>
               <PostList posts={relatedPosts} />
             </section>
+          )}
+          {isNewsletterEnabled && (
+            <div className="mx-auto mt-12 max-w-[42rem]">
+              <NewsletterForm />
+            </div>
           )}
           <Separator />
           <SuggestEditSection slug={postSlug} title={postTitle} />

--- a/components/molecules/newsletter-form/newsletter-form.tsx
+++ b/components/molecules/newsletter-form/newsletter-form.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { type FormEvent, useState } from 'react';
+
+import { Button } from '@/components/atoms/button';
+import { Input } from '@/components/atoms/input';
+import { isNewsletterEnabled } from '@/config/newsletter';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+interface SubscribeResponse {
+  ok: boolean;
+  message?: string;
+}
+
+/**
+ * ニュースレター購読フォーム。NEXT_PUBLIC_NEWSLETTER_ENABLED=true のときのみ表示。
+ * 送信は /api/newsletter プロキシ経由。bot 対策にハニーポット(website)を仕込む。
+ */
+export const NewsletterForm = () => {
+  const [email, setEmail] = useState('');
+  const [website, setWebsite] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+
+  if (!isNewsletterEnabled) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus('loading');
+    try {
+      const response = await fetch('/api/newsletter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, website }),
+      });
+      const data = (await response.json()) as SubscribeResponse;
+      setStatus(data.ok ? 'success' : 'error');
+      setMessage(data.message ?? '');
+      if (data.ok) {
+        setEmail('');
+      }
+    } catch {
+      setStatus('error');
+      setMessage('通信エラーが発生しました。');
+    }
+  };
+
+  return (
+    <section className="not-prose overflow-hidden rounded-xl bg-card p-6 text-card-foreground shadow-xs ring-1 ring-foreground/10">
+      <h2 className="text-lg font-semibold text-foreground">ニュースレター購読</h2>
+      <p className="mt-1 text-sm text-muted-foreground">新着記事や気づきをメールでお届けします。</p>
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-2 sm:flex-row">
+        {/* ハニーポット(視覚的に隠す。bot が埋めたら黙殺) */}
+        <input
+          type="text"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+          aria-hidden
+          className="sr-only"
+          value={website}
+          onChange={(event) => setWebsite(event.target.value)}
+        />
+        <Input
+          type="email"
+          required
+          placeholder="you@example.com"
+          aria-label="メールアドレス"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          className="sm:flex-1"
+        />
+        <Button type="submit" disabled={status === 'loading'}>
+          {status === 'loading' ? '送信中...' : '購読する'}
+        </Button>
+      </form>
+      {status === 'success' && <p className="mt-2 text-sm text-success">{message}</p>}
+      {status === 'error' && <p className="mt-2 text-sm text-destructive">{message}</p>}
+    </section>
+  );
+};

--- a/config/newsletter.ts
+++ b/config/newsletter.ts
@@ -1,0 +1,7 @@
+/**
+ * ニュースレター購読の表示フラグ。
+ * NEXT_PUBLIC_NEWSLETTER_ENABLED=true のときのみ購読UIを表示する(env 未設定で自動非表示)。
+ * 実際の購読は app/api/newsletter/route.ts がサーバ専用 env BUTTONDOWN_API_KEY を使って
+ * プロバイダ(buttondown 想定)へプロキシし、APIキーをクライアントに露出しない。
+ */
+export const isNewsletterEnabled = process.env.NEXT_PUBLIC_NEWSLETTER_ENABLED === 'true';


### PR DESCRIPTION
## 変更(env ゲート)
- `config/newsletter.ts`: `NEXT_PUBLIC_NEWSLETTER_ENABLED` で表示制御(未設定で非表示)
- `app/api/newsletter`: サーバ専用 `BUTTONDOWN_API_KEY` で buttondown へプロキシ(キー非露出/ハニーポット黙殺/メール検証/二重登録ハンドリング)
- `newsletter-form`: Input+Button のMVPフォーム(送信中・成功・失敗表示)
- 記事末(関連記事の後)に配置

## 運用に必要(別途)
buttondown 契約 + `BUTTONDOWN_API_KEY` と `NEXT_PUBLIC_NEWSLETTER_ENABLED=true` を設定。未設定時は完全非表示。

検証: check 0/0・build 成功(/api/newsletter 生成)。

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)