### PR TITLE
feat: 記事末に著者バイオボックス(E-E-A-T)を追加 (#138)

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -7,6 +7,7 @@ import { Breadcrumb } from '@/components/molecules/breadcrumb/breadcrumb';
 import { ReadingProgress } from '@/components/molecules/reading-progress/reading-progress';
 import { ShareButtons } from '@/components/molecules/share-buttons/share-buttons';
 import { GiscusComments } from '@/components/organisms/comments/giscus-comments';
+import { AuthorBio } from '@/components/organisms/author-bio/author-bio';
 import { NewsletterForm } from '@/components/molecules/newsletter-form/newsletter-form';
 import { isNewsletterEnabled } from '@/config/newsletter';
 import { SuggestEditLink } from '@/components/molecules/suggest-edit-link/suggest-edit-link';
@@ -76,6 +77,9 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
           </article>
           <div className="mx-auto mt-6 max-w-[42rem]">
             <ShareButtons url={postUrl} title={postTitle} />
+          </div>
+          <div className="mx-auto mt-8 max-w-[42rem]">
+            <AuthorBio />
           </div>
           <PromoBlock placement="article-bottom" />
           {relatedPosts.length > 0 && (

--- a/components/organisms/author-bio/author-bio.tsx
+++ b/components/organisms/author-bio/author-bio.tsx
@@ -1,0 +1,53 @@
+import { buttonVariants } from '@/components/atoms/button';
+import { siteConfig } from '@/config/site';
+
+const followLinks = [
+  { label: 'X', href: siteConfig.links.twitter },
+  { label: 'GitHub', href: siteConfig.links.github },
+  { label: 'Zenn', href: siteConfig.links.zenn },
+  { label: 'Qiita', href: siteConfig.links.qiita },
+].filter((link) => Boolean(link.href));
+
+const initial = siteConfig.author.name.charAt(0).toUpperCase();
+
+/**
+ * 記事末尾の著者バイオボックス(E-E-A-T / フォロー導線)。
+ * フォローリンクには rel="me" を付与し本人確認可能にする。
+ */
+export const AuthorBio = () => (
+  <section className="not-prose overflow-hidden rounded-xl bg-card p-6 text-card-foreground shadow-xs ring-1 ring-foreground/10">
+    <div className="flex items-start gap-4">
+      {siteConfig.author.avatar ? (
+        // 任意パスのプロフィール画像。外部最適化を避けるため img を使用
+        // oxlint-disable-next-line
+        <img
+          src={siteConfig.author.avatar}
+          alt={siteConfig.author.name}
+          className="size-14 shrink-0 rounded-full object-cover ring-1 ring-foreground/10"
+        />
+      ) : (
+        <div className="flex size-14 shrink-0 items-center justify-center rounded-full bg-primary text-lg font-bold text-primary-foreground">
+          {initial}
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-xs text-muted-foreground">Author</p>
+        <p className="text-base font-semibold text-foreground">{siteConfig.author.name}</p>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">{siteConfig.author.bio}</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {followLinks.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              target="_blank"
+              rel="me noopener noreferrer"
+              className={buttonVariants({ variant: 'outline', size: 'sm' })}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+);

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,5 +1,11 @@
 export const siteConfig = {
   description: '技術的な学びや日々の気づきを共有しています',
+  author: {
+    name: 'ebaryo.dev',
+    bio: 'Software Engineer。Generative AI / Rust に関心。フロントエンド・データエンジニアリングの実務と日々の学びを発信しています。',
+    /** プロフィール画像パス(任意)。未設定時はイニシャルを表示。 */
+    avatar: '',
+  },
   links: {
     github: 'https://github.com/ryo-ebata',
     qiita: 'https://qiita.com/ryo0403',

--- a/lib/jsonld.test.ts
+++ b/lib/jsonld.test.ts
@@ -71,6 +71,8 @@ describe('generateArticleJsonLd', () => {
     expect(result.author).toEqual({
       '@type': 'Person',
       name: expect.any(String),
+      url: expect.any(String),
+      sameAs: expect.any(Array),
     });
     expect(result.publisher).toEqual({
       '@type': 'Organization',

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -16,6 +16,8 @@ export const generateArticleJsonLd = (
     author: {
       '@type': 'Person',
       name: siteConfig.name,
+      url: `${siteConfig.url}/about`,
+      sameAs: collectSocialLinks(),
     },
     dateModified: metadata.updatedAt || metadata.createdAt,
     datePublished: metadata.createdAt,


### PR DESCRIPTION
## 変更
- `config/site.ts`: `author`(name/bio/avatar)。avatar 未設定時はイニシャル円を表示
- `author-bio`: プロフィール + 自己紹介 + フォロー導線(X/GitHub/Zenn/Qiita、rel="me")
- `generateArticleJsonLd` の author に `url`(About) と `sameAs` を付与し著者エンティティ強化
- 記事末(シェアの後)に配置、jsonld.test 更新

検証: check 0/0・jsonld 12件 pass・build 成功。

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)