### PR TITLE
feat: 本文へのスキップリンクを追加 (#139)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -84,8 +84,16 @@ const createThemeScript = (): string =>
 
 const PageLayout = ({ children }: { children: ReactNode }) => (
   <>
+    <a
+      href="#main"
+      className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow focus:outline-none focus:ring-2 focus:ring-ring"
+    >
+      本文へスキップ
+    </a>
     <Header />
-    <main>{children}</main>
+    <main id="main" tabIndex={-1}>
+      {children}
+    </main>
     <Footer />
   </>
 );


### PR DESCRIPTION
WCAG 2.4.1(Bypass Blocks)。body 直下に sr-only/focus:not-sr-only のスキップリンク、`<main id="main" tabIndex={-1}>` をアンカー対象に。検証: check 0/0・build 成功。

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)