### PR TITLE
feat: prefers-reduced-motion でモーションを低減 (#140)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -302,3 +302,25 @@
     background: var(--card);
   }
 }
+
+/* ==============================================
+   prefers-reduced-motion: モーション低減 (WCAG 2.3.3)
+   OSの「視差効果/モーションを減らす」設定時、CSS由来の演出を実質無効化する。
+   ============================================== */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* View Transitions のページ遷移演出を無効化 */
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
WCAG 2.3.3。globals.css に `@media (prefers-reduced-motion: reduce)` を追加し、CSS の animation/transition を実質無効化 + View Transitions 演出を停止。

注: `bubble-tag-filter` の canvas(rAF)は JS 制御のため本CSS対応の対象外(別途 matchMedia ガードが必要)と申し送り。

検証: check 0/0・build 成功。

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)