### PR TITLE
feat: 素のリンクに統一フォーカスインジケータを追加 (#141)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -215,6 +215,14 @@
     @apply border-border outline-ring/50;
   }
 
+  /* リンク等の統一フォーカスインジケータ (WCAG 2.4.7 / 2.4.11)。
+     button/input 等の atom は focus-visible:ring 済みのため、ここでは素の <a> を補う。 */
+  a:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
   html {
     @apply bg-[#faf8f4] dark:bg-[#1c1a17];
   }


### PR DESCRIPTION
WCAG 2.4.7/2.4.11。globals.css に `a:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px }` を追加。atom(button/input)は ring 済みのため素の <a> を補完し、暖色テーマで一貫したフォーカス可視性に。検証: check 0/0・build 成功。

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)