### PR TITLE
feat: ナビに aria-current、テーマトグルに aria-pressed を付与 (#142)

### DIFF
--- a/components/atoms/theme-toggle/theme-toggle.tsx
+++ b/components/atoms/theme-toggle/theme-toggle.tsx
@@ -20,7 +20,13 @@ export const ThemeToggle = () => {
   };
 
   return (
-    <Button variant="ghost" size="icon" className="cursor-pointer" onClick={handleClick}>
+    <Button
+      variant="ghost"
+      size="icon"
+      className="cursor-pointer"
+      aria-pressed={theme === 'dark'}
+      onClick={handleClick}
+    >
       <Sun
         className={cn('size-4 rotate-0 scale-100 transition-all', 'dark:-rotate-90 dark:scale-0')}
       />

--- a/components/organisms/header/header.test.tsx
+++ b/components/organisms/header/header.test.tsx
@@ -27,6 +27,12 @@ describe('Header', () => {
     expect(screen.getByRole('link', { name: 'Blog' })).toBeInTheDocument();
   });
 
+  it('現在地リンクに aria-current="page" を付与する', () => {
+    render(<Header />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'About' })).not.toHaveAttribute('aria-current');
+  });
+
   it('テーマ切り替えボタンを表示する', () => {
     render(<Header />);
     expect(screen.getByText('テーマを切り替え')).toBeInTheDocument();

--- a/components/organisms/header/header.tsx
+++ b/components/organisms/header/header.tsx
@@ -25,7 +25,11 @@ interface NavLinkProps {
 }
 
 const NavLink = ({ href, isActive, label }: NavLinkProps) => (
-  <Link href={href} className={getLinkClassName(isActive)}>
+  <Link
+    href={href}
+    aria-current={isActive ? 'page' : undefined}
+    className={getLinkClassName(isActive)}
+  >
     {label}
   </Link>
 );


### PR DESCRIPTION
- header NavLink: 現在地に `aria-current="page"`(未選択は属性なし)
- theme-toggle: `aria-pressed={theme === 'dark'}`
- header.test に aria-current アサーション追加

属性追加のみで挙動・見た目に影響なし。検証: check 0/0・header+toggle 7件 pass・build 成功。

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)