### PR TITLE
perf: 画像配信に AVIF を追加 (#143)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -56,6 +56,8 @@ const nextConfig: NextConfig = {
   compress: true,
   /* 画像最適化設定 */
   images: {
+    /* AVIF を優先し、非対応ブラウザには WebP を自動フォールバック */
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         hostname: 'images.microcms-assets.io',


### PR DESCRIPTION
`images.formats` を `['image/avif', 'image/webp']` に設定。AVIF 優先で軽量化、非対応ブラウザは WebP に自動フォールバック。検証: check 0/0・build 成功。

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)