### PR TITLE
feat: 検索をタイトル/タグ/説明/本文の横断検索に拡張 (#144)

### DIFF
--- a/app/blog/container.tsx
+++ b/app/blog/container.tsx
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { paginateItems } from '@/lib/pagination';
 import { getAllPostsMetadata } from '@/lib/micro-cms/blog';
-import { filterPostsByTitle } from '@/lib/search';
+import { filterPostsByQuery } from '@/lib/search';
 import { aggregateTags, filterPostsByTags } from '@/lib/tags';
 import { BlogListPresenter } from './presenter';
 
@@ -23,7 +23,7 @@ export const BlogListContainer = async ({
 
     const tagCounts = aggregateTags(allPostsMetadata);
     const filteredByTags = filterPostsByTags(allPostsMetadata, selectedTags);
-    const filteredPosts = filterPostsByTitle(filteredByTags, searchQuery);
+    const filteredPosts = filterPostsByQuery(filteredByTags, searchQuery);
     const { items: posts, totalPages } = paginateItems(filteredPosts, currentPage, POSTS_PER_PAGE);
 
     return (

--- a/components/atoms/search-input/search-input.test.tsx
+++ b/components/atoms/search-input/search-input.test.tsx
@@ -12,7 +12,7 @@ describe('SearchInput', () => {
 
     const input = screen.getByRole('textbox');
     expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute('placeholder', 'タイトルで検索...');
+    expect(input).toHaveAttribute('placeholder', '本文・タグも検索...');
   });
 
   it('初期値を表示する', () => {

--- a/components/atoms/search-input/search-input.tsx
+++ b/components/atoms/search-input/search-input.tsx
@@ -26,7 +26,7 @@ const createHandleCompositionEnd =
 
 export const SearchInput = ({
   onChange,
-  placeholder = 'タイトルで検索...',
+  placeholder = '本文・タグも検索...',
   value,
 }: SearchInputProps) => {
   const [inputValue, setInputValue] = useState(value);

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -27,6 +27,8 @@ export interface BaseContentMetadata {
   description?: string;
   draft?: boolean;
   eyecatch?: { url: string; height?: number; width?: number };
+  /** 検索用の本文プレーンテキスト(一覧取得時のみ付与)。 */
+  searchText?: string;
   slug: string;
   tags?: string[];
   title: string;

--- a/lib/micro-cms/blog.test.ts
+++ b/lib/micro-cms/blog.test.ts
@@ -11,6 +11,7 @@ vi.mock('./client', () => ({
 
 vi.mock('./count-characters', () => ({
   countHtmlCharacters: vi.fn(() => 100),
+  extractPlainText: vi.fn(() => 'テスト本文'),
 }));
 
 const createMockBlog = (overrides: Partial<MicroCMSBlog> = {}): MicroCMSBlog => ({

--- a/lib/micro-cms/blog.ts
+++ b/lib/micro-cms/blog.ts
@@ -2,7 +2,7 @@ import type { BaseContentMetadata } from '@/lib/content';
 import type { MicroCMSBlog, MicroCMSContentData, MicroCMSListResponse } from './types';
 import { toBaseContentMetadata } from './types';
 import { microCmsClient } from './client';
-import { countHtmlCharacters } from './count-characters';
+import { countHtmlCharacters, extractPlainText } from './count-characters';
 
 const MICROCMS_LIST_LIMIT = 100;
 const ENDPOINT = 'blog';
@@ -36,7 +36,10 @@ export const getAllPostsMetadata = async (): Promise<BaseContentMetadata[]> => {
   const blogs = await fetchAllBlogs();
 
   return blogs
-    .map((blog) => toBaseContentMetadata(blog, countHtmlCharacters(blog.content)))
+    .map((blog) => ({
+      ...toBaseContentMetadata(blog, countHtmlCharacters(blog.content)),
+      searchText: extractPlainText(blog.content),
+    }))
     .sort(sortByDateDescending);
 };
 

--- a/lib/micro-cms/count-characters.ts
+++ b/lib/micro-cms/count-characters.ts
@@ -28,14 +28,13 @@ const extractTextFromHast = (tree: Root): string => {
   return texts.join('');
 };
 
-export const countHtmlCharacters = (html: string): number => {
+/** HTML から pre/code を除いたプレーンテキストを抽出する(空白正規化済み)。 */
+export const extractPlainText = (html: string): string => {
   if (!html) {
-    return 0;
+    return '';
   }
-
   const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
-  const text = extractTextFromHast(tree);
-  const normalized = text.replace(/\s+/g, ' ').trim();
-
-  return normalized.length;
+  return extractTextFromHast(tree).replace(/\s+/g, ' ').trim();
 };
+
+export const countHtmlCharacters = (html: string): number => extractPlainText(html).length;

--- a/lib/search.test.ts
+++ b/lib/search.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { BaseContentMetadata } from './content';
-import { filterPostsByTitle } from './search';
+import { filterPostsByQuery, filterPostsByTitle } from './search';
 
 /*
  * テスト用定数
@@ -100,5 +100,48 @@ describe('filterPostsByTitle', () => {
     const result = filterPostsByTitle(mockPosts, '日記');
     expect(result).toHaveLength(EXPECTED_SINGLE_RESULT);
     expect(result[FIRST_INDEX].slug).toBe('daily-note');
+  });
+});
+
+describe('filterPostsByQuery', () => {
+  const posts: BaseContentMetadata[] = [
+    {
+      createdAt: '2024-01-01',
+      slug: 'a',
+      title: 'Aの記事',
+      tags: ['Rust'],
+      description: '入門ガイド',
+      searchText: 'ownership と borrow checker の話',
+      updatedAt: '2024-01-01',
+    },
+    {
+      createdAt: '2024-01-02',
+      slug: 'b',
+      title: 'Bの記事',
+      tags: ['Go'],
+      searchText: 'goroutine と channel の話',
+      updatedAt: '2024-01-02',
+    },
+  ];
+
+  it('タイトルで一致する', () => {
+    expect(filterPostsByQuery(posts, 'Aの').map((post) => post.slug)).toEqual(['a']);
+  });
+
+  it('タグで一致する', () => {
+    expect(filterPostsByQuery(posts, 'rust').map((post) => post.slug)).toEqual(['a']);
+  });
+
+  it('説明文で一致する', () => {
+    expect(filterPostsByQuery(posts, '入門').map((post) => post.slug)).toEqual(['a']);
+  });
+
+  it('本文(searchText)で一致する', () => {
+    expect(filterPostsByQuery(posts, 'goroutine').map((post) => post.slug)).toEqual(['b']);
+  });
+
+  it('空クエリは全件、マッチ無しは空配列', () => {
+    expect(filterPostsByQuery(posts, '')).toEqual(posts);
+    expect(filterPostsByQuery(posts, 'python')).toHaveLength(EXPECTED_NO_RESULT);
   });
 });

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -14,3 +14,32 @@ export const filterPostsByTitle = (
 
   return posts.filter((post) => post.title.toLowerCase().includes(lowerQuery));
 };
+
+/**
+ * タイトル・タグ・説明・本文プレーンテキストを横断して部分一致検索する。
+ * 本文(searchText)は一覧取得時のみ付与されるため、無い場合は対象から外れる。
+ */
+export const filterPostsByQuery = (
+  posts: BaseContentMetadata[],
+  query: string
+): BaseContentMetadata[] => {
+  const trimmedQuery = query.trim();
+
+  if (!trimmedQuery) {
+    return posts;
+  }
+
+  const lowerQuery = trimmedQuery.toLowerCase();
+
+  return posts.filter((post) => {
+    const haystack = [
+      post.title,
+      post.description ?? '',
+      post.searchText ?? '',
+      ...(post.tags ?? []),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(lowerQuery);
+  });
+};


### PR DESCRIPTION
## 変更
- `lib/search.ts`: `filterPostsByQuery`(title/tags/description/searchText を横断部分一致)
- `count-characters`: `extractPlainText` を切り出し共通化
- `blog.getAllPostsMetadata`: 取得済み本文から `searchText` を付与(追加フェッチ不要)
- `BaseContentMetadata.searchText?` 追加、一覧コンテナを新関数に切替
- 検索プレースホルダを「本文・タグも検索...」に
- search/blog/search-input テスト更新

新規ライブラリ不要・サーバーサイドフィルタ構成を維持。検証: check 0/0・unit 247件 pass・build 成功。

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)