### PR TITLE
feat: タグ専用一覧ページ /blog/tag/[slug] を SSG で追加 (#145)

### DIFF
--- a/app/blog/tag/[slug]/page.tsx
+++ b/app/blog/tag/[slug]/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { BackLink } from '@/components/atoms';
+import { Container } from '@/components/organisms';
+import { PostList } from '@/components/organisms/post-list/post-list';
+import { siteConfig } from '@/config/site';
+import { generateMetadata as generatePageMetadata } from '@/lib/metadata';
+import { getAllPostsMetadata } from '@/lib/micro-cms/blog';
+import { aggregateTags, filterPostsByTags } from '@/lib/tags';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+/* ビルド時に全タグ分を SSG する */
+export const dynamicParams = false;
+
+export const generateStaticParams = async () => {
+  const posts = await getAllPostsMetadata();
+  /* 日本語タグもそのまま slug にする(Next.js が URL エンコードを処理) */
+  return aggregateTags(posts).map(({ tag }) => ({ slug: tag }));
+};
+
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { slug } = await params;
+  return generatePageMetadata({
+    title: `タグ: ${slug}`,
+    description: `「${slug}」タグの記事一覧 | ${siteConfig.name}`,
+    url: `${siteConfig.url}/blog/tag/${encodeURIComponent(slug)}`,
+  });
+};
+
+const TagPage = async ({ params }: Props) => {
+  const { slug } = await params;
+  const posts = await getAllPostsMetadata();
+  const filtered = filterPostsByTags(posts, [slug]);
+
+  if (filtered.length === 0) {
+    notFound();
+  }
+
+  return (
+    <Container maxWidth="4xl">
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">タグ</p>
+          <h1 className="scroll-m-20 text-3xl font-bold text-foreground">{slug}</h1>
+          <p className="text-sm text-muted-foreground">{filtered.length} 件の記事</p>
+        </div>
+        <PostList posts={filtered} />
+        <div className="text-end">
+          <BackLink href="/blog" label="ブログ一覧に戻る" />
+        </div>
+      </div>
+    </Container>
+  );
+};
+
+export default TagPage;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { BaseContentMetadata } from '@/lib/content';
 import type { MetadataRoute } from 'next';
 import { getAllPostsMetadata } from '@/lib/micro-cms/blog';
+import { aggregateTags } from '@/lib/tags';
 import { siteConfig } from '@/config/site';
 
 /* 優先度定数 */
@@ -46,12 +47,21 @@ const createBlogPostEntries = (posts: BaseContentMetadata[]): MetadataRoute.Site
     url: `${siteConfig.url}/blog/${post.slug}`,
   }));
 
+const createTagEntries = (posts: BaseContentMetadata[]): MetadataRoute.Sitemap =>
+  aggregateTags(posts).map(({ tag }) => ({
+    changeFrequency: 'weekly',
+    lastModified: new Date(),
+    priority: PRIORITY_MEDIUM,
+    url: `${siteConfig.url}/blog/tag/${encodeURIComponent(tag)}`,
+  }));
+
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   const posts = await getAllPostsMetadata();
   const staticPages = createStaticPages();
   const blogPosts = createBlogPostEntries(posts);
+  const tagPages = createTagEntries(posts);
 
-  return [...staticPages, ...blogPosts];
+  return [...staticPages, ...blogPosts, ...tagPages];
 };
 
 export default sitemap;

--- a/components/molecules/tag-list.tsx
+++ b/components/molecules/tag-list.tsx
@@ -9,8 +9,8 @@ interface TagListProps {
 }
 
 const Tag = ({ tag }: { tag: string }) => {
-  /* Nuqsの形式に合わせて、tagsパラメータをカンマ区切りで設定 */
-  const tagUrl = `/blog?tags=${encodeURIComponent(tag)}`;
+  /* タグ専用一覧ページ(SSG)へのリンク。内部リンク網を強化する */
+  const tagUrl = `/blog/tag/${encodeURIComponent(tag)}`;
 
   return (
     <Link href={tagUrl} className={badgeVariants({ variant: 'secondary' })}>

--- a/components/molecules/tag-list/tag-list.test.tsx
+++ b/components/molecules/tag-list/tag-list.test.tsx
@@ -12,7 +12,7 @@ describe('TagList', () => {
   it('各タグがリンクとしてレンダリングされる', () => {
     render(<TagList tags={['React']} />);
     const link = screen.getByRole('link', { name: 'React' });
-    expect(link).toHaveAttribute('href', '/blog?tags=React');
+    expect(link).toHaveAttribute('href', '/blog/tag/React');
   });
 
   it('空配列の場合何もレンダリングしない', () => {
@@ -23,6 +23,6 @@ describe('TagList', () => {
   it('タグ名をURLエンコードする', () => {
     render(<TagList tags={['C++']} />);
     const link = screen.getByRole('link', { name: 'C++' });
-    expect(link).toHaveAttribute('href', '/blog?tags=C%2B%2B');
+    expect(link).toHaveAttribute('href', '/blog/tag/C%2B%2B');
   });
 });


### PR DESCRIPTION
## 変更
- `app/blog/tag/[slug]/page.tsx`: 全タグを generateStaticParams で SSG、filterPostsByTags で絞り込み PostList 再利用、canonical/metadata 設定、0件は404
- `app/sitemap.ts`: 全タグページURLを追加
- `tag-list`: リンク先を `/blog/tag/[slug]` に変更(内部リンク網強化)、テスト更新
- 日本語タグは raw slug で扱い Next の URL エンコードに委譲

既存のクエリ式フィルタ(/blog?tags=)と共存。検証: check 0/0・tag-list 4件 pass・build で /blog/tag/[slug] の SSG 生成を確認。

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)