### PR TITLE
feat: JSON Feed(/feed.json)を併設 (#146)

### DIFF
--- a/app/feed.json/route.test.ts
+++ b/app/feed.json/route.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/micro-cms/blog', () => ({
+  getAllPostsMetadata: vi.fn(async () => [
+    {
+      slug: 'a',
+      title: 'A記事',
+      description: '概要A',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-02T00:00:00.000Z',
+      tags: ['Rust'],
+    },
+  ]),
+}));
+
+import { GET } from './route';
+
+describe('feed.json', () => {
+  it('JSON Feed 1.1 を application/feed+json で返す', async () => {
+    const response = await GET();
+    expect(response.headers.get('content-type')).toContain('application/feed+json');
+
+    const feed = await response.json();
+    expect(feed.version).toBe('https://jsonfeed.org/version/1.1');
+    expect(feed.feed_url).toContain('/feed.json');
+    expect(feed.items).toHaveLength(1);
+    expect(feed.items[0].url).toContain('/blog/a');
+    expect(feed.items[0].title).toBe('A記事');
+    expect(feed.items[0].date_published).toBe('2025-01-01T00:00:00.000Z');
+    expect(feed.items[0].tags).toEqual(['Rust']);
+  });
+});

--- a/app/feed.json/route.ts
+++ b/app/feed.json/route.ts
@@ -1,0 +1,38 @@
+import { getAllPostsMetadata } from '@/lib/micro-cms/blog';
+import { siteConfig } from '@/config/site';
+
+/**
+ * JSON Feed 1.1 (https://jsonfeed.org/version/1.1) を配信する。
+ * 既存の RSS(app/rss.xml) と同じく getAllPostsMetadata の結果を変換する。
+ */
+export const GET = async () => {
+  const posts = await getAllPostsMetadata();
+  const siteUrl = siteConfig.url;
+
+  const feed = {
+    version: 'https://jsonfeed.org/version/1.1',
+    title: siteConfig.name,
+    description: siteConfig.description,
+    home_page_url: siteUrl,
+    feed_url: `${siteUrl}/feed.json`,
+    language: 'ja',
+    items: posts.map((post) => {
+      const url = `${siteUrl}/blog/${post.slug}`;
+      return {
+        id: url,
+        url,
+        title: post.title,
+        date_published: new Date(post.createdAt).toISOString(),
+        ...(post.updatedAt && { date_modified: new Date(post.updatedAt).toISOString() }),
+        ...(post.description && { summary: post.description }),
+        ...(post.tags && post.tags.length > 0 && { tags: post.tags }),
+      };
+    }),
+  };
+
+  return new Response(JSON.stringify(feed), {
+    headers: {
+      'content-type': 'application/feed+json; charset=utf-8',
+    },
+  });
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,6 +28,7 @@ export const metadata: Metadata = {
     canonical: siteConfig.url,
     types: {
       'application/rss+xml': `${siteConfig.url}/rss.xml`,
+      'application/feed+json': `${siteConfig.url}/feed.json`,
     },
   },
   description: siteConfig.description,

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -65,6 +65,7 @@ export const generateMetadata = (params: MetadataParams): Metadata => {
       canonical: pageUrl,
       types: {
         'application/rss+xml': `${siteConfig.url}/rss.xml`,
+        'application/feed+json': `${siteConfig.url}/feed.json`,
       },
     },
     description,


### PR DESCRIPTION
- `app/feed.json/route.ts`: JSON Feed 1.1 を `application/feed+json` で配信(RSS と同じ `getAllPostsMetadata` を変換)
- `alternates.types` に `application/feed+json` を追加(layout + generateMetadata)。RSS autodiscovery は #129 で対応済み
- feed.json の形式テスト追加

検証: check 0/0・feed テスト pass・build で /feed.json 生成。

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)