### PR TITLE
feat: アフィリエイト/PR開示ラベルを追加 (#147)

### DIFF
--- a/components/molecules/affiliate-card/affiliate-card.tsx
+++ b/components/molecules/affiliate-card/affiliate-card.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/components/atoms/badge';
 import { StoreButtons } from '@/components/molecules/store-buttons/store-buttons';
 import type { AffiliateItem } from '@/config/ads';
 import { resolveStoreLinks } from '@/config/ads';
@@ -32,6 +33,9 @@ export function AffiliateCard({ item }: { item: AffiliateItem }) {
           />
         )}
         <div className="min-w-0 flex-1">
+          <Badge variant="outline" className="mb-1.5 h-4 px-1.5 text-[10px]">
+            PR
+          </Badge>
           <p className="line-clamp-2 text-sm font-semibold text-card-foreground">{item.title}</p>
           {item.price && (
             <p className="mt-1 text-sm font-bold text-foreground tabular-nums">{item.price}</p>

--- a/components/molecules/affiliate-disclosure/affiliate-disclosure.tsx
+++ b/components/molecules/affiliate-disclosure/affiliate-disclosure.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '@/components/atoms/badge';
+import { cn } from '@/lib/utils';
+
+/**
+ * アフィリエイト/広告の読者向け開示ラベル(景表法ステマ規制・ASP規約対応)。
+ * rel="sponsored"(検索エンジン向け)とは別に、人間が読める明示開示を担う。
+ */
+export const AffiliateDisclosure = ({ className }: { className?: string }) => (
+  <p className={cn('flex items-center gap-1.5 text-xs text-muted-foreground', className)}>
+    <Badge variant="outline">PR</Badge>
+    広告（アフィリエイトリンク）を含みます
+  </p>
+);

--- a/components/organisms/affiliate-recommend/affiliate-recommend.tsx
+++ b/components/organisms/affiliate-recommend/affiliate-recommend.tsx
@@ -1,4 +1,5 @@
 import { AffiliateCard } from '@/components/molecules/affiliate-card/affiliate-card';
+import { AffiliateDisclosure } from '@/components/molecules/affiliate-disclosure/affiliate-disclosure';
 import { Separator } from '@/components/atoms/separator';
 import { recommendedItems } from '@/config/ads';
 
@@ -17,7 +18,10 @@ export function AffiliateRecommend({ heading = 'この記事のおすすめ' }: 
 
   return (
     <aside className="not-prose my-8">
-      <h2 className="text-base font-semibold text-foreground">{heading}</h2>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-base font-semibold text-foreground">{heading}</h2>
+        <AffiliateDisclosure />
+      </div>
       <Separator className="my-4" />
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {recommendedItems.map((item) => (


### PR DESCRIPTION
景表法ステマ規制・ASP規約が求める読者向け明示開示を追加。
- `affiliate-disclosure`: 「PR 広告（アフィリエイトリンク）を含みます」
- `affiliate-recommend`: 見出し横に開示
- `affiliate-card`: 一覧経路カバー用に小さな PR バッジ

検証: check 0/0・build 成功。

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)