### PR TITLE
feat: アフィリクリックを GA4 affiliate_click で計測 (#148)

### DIFF
--- a/components/molecules/affiliate-card/affiliate-card.tsx
+++ b/components/molecules/affiliate-card/affiliate-card.tsx
@@ -46,7 +46,7 @@ export function AffiliateCard({ item }: { item: AffiliateItem }) {
         </div>
       </div>
       <div className="mt-auto px-4 pb-4">
-        <StoreButtons links={links} />
+        <StoreButtons links={links} productName={item.title} placement="recommend" />
       </div>
     </div>
   );

--- a/components/molecules/store-buttons/store-buttons.tsx
+++ b/components/molecules/store-buttons/store-buttons.tsx
@@ -1,19 +1,26 @@
+'use client';
+
 import type { StoreLink } from '@/config/ads';
 
 import { Button } from '@/components/atoms/button';
+import { trackAffiliateClick } from '@/lib/analytics';
 
 /** アフィリエイトリンクに必須の rel 属性 */
 const AFFILIATE_REL = 'sponsored nofollow noopener noreferrer';
 
 interface StoreButtonsProps {
   links: StoreLink[];
+  /** 計測用の商品名(GA4 affiliate_click の product) */
+  productName?: string;
+  /** 計測用の配置(GA4 affiliate_click の placement) */
+  placement?: string;
 }
 
 /**
  * Amazon / 楽天 / Yahoo などのストアリンクをボタン列で表示する共通パーツ。
- * すべて新規タブ + rel="sponsored nofollow" 付き。
+ * すべて新規タブ + rel="sponsored nofollow" 付き。クリックを GA4 に計測する。
  */
-export function StoreButtons({ links }: StoreButtonsProps) {
+export function StoreButtons({ links, productName, placement }: StoreButtonsProps) {
   if (links.length === 0) {
     return null;
   }
@@ -25,6 +32,9 @@ export function StoreButtons({ links }: StoreButtonsProps) {
           key={link.store}
           variant="secondary"
           size="sm"
+          onClick={() =>
+            trackAffiliateClick({ store: link.store, product: productName, placement })
+          }
           render={<a href={link.href} target="_blank" rel={AFFILIATE_REL} />}
         >
           {link.label}で見る

--- a/components/organisms/product-link/product-link.tsx
+++ b/components/organisms/product-link/product-link.tsx
@@ -59,7 +59,7 @@ export function ProductLink({ name, asin, rakuten, yahoo, image, desc }: Product
       </div>
       <Separator />
       <div className="p-4">
-        <StoreButtons links={links} />
+        <StoreButtons links={links} productName={name} placement="article-product" />
       </div>
     </div>
   );

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,21 @@
+interface AffiliateClickParams {
+  store: string;
+  product?: string;
+  placement?: string;
+}
+
+type GtagFn = (command: 'event', eventName: string, params?: Record<string, unknown>) => void;
+
+/**
+ * アフィリエイトリンクのクリックを GA4 の affiliate_click カスタムイベントとして送信する。
+ * gtag 未ロード時(GA4 未導入)は no-op になり、導入後に自動で計測が始まる。
+ */
+export const trackAffiliateClick = ({ store, product, placement }: AffiliateClickParams): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const gtag = (window as unknown as { gtag?: GtagFn }).gtag;
+  if (typeof gtag === 'function') {
+    gtag('event', 'affiliate_click', { store, product, placement });
+  }
+};


### PR DESCRIPTION
- `lib/analytics.ts`: `trackAffiliateClick({store,product,placement})`。**gtag 未ロード時 no-op**
- `store-buttons`: クリックで `affiliate_click` 送信(productName/placement prop)
- `affiliate-card`(placement=recommend) / `product-link`(placement=article-product) から伝搬

GA4本体(#10)導入後に自動計測開始する先回り実装。未導入でも壊れない。検証: check 0/0・build 成功。

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)