### PR TITLE
feat: 実ユーザーCore Web Vitals(RUM)を計測 (#149)

### DIFF
--- a/app/_components/web-vitals.tsx
+++ b/app/_components/web-vitals.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useReportWebVitals } from 'next/web-vitals';
+
+import { reportWebVital } from '@/lib/analytics';
+
+/**
+ * 実ユーザー環境の Core Web Vitals(LCP/INP/CLS/FCP/TTFB)を計測する RUM コンポーネント。
+ * Next.js 標準の useReportWebVitals を使い、収集値は analytics(gtag)へ束ねる。
+ * gtag 未導入時は外部送信されない。
+ */
+export const WebVitals = () => {
+  useReportWebVitals((metric) => {
+    reportWebVital({
+      name: metric.name,
+      value: metric.value,
+      rating: metric.rating,
+      id: metric.id,
+    });
+  });
+  return null;
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { type ReactNode, Suspense } from 'react';
 import { ThemeProvider } from '@/contexts/theme-provider';
 import { generateOrganizationJsonLd } from '@/lib/jsonld';
 import { siteConfig } from '@/config/site';
+import { WebVitals } from './_components/web-vitals';
 
 // oxlint-disable-next-line new-cap -- BIZ_UDPGothic is exported from next/font/google
 const bizUDPGothic = BIZ_UDPGothic({
@@ -85,6 +86,7 @@ const createThemeScript = (): string =>
 
 const PageLayout = ({ children }: { children: ReactNode }) => (
   <>
+    <WebVitals />
     <a
       href="#main"
       className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow focus:outline-none focus:ring-2 focus:ring-ring"

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -19,3 +19,32 @@ export const trackAffiliateClick = ({ store, product, placement }: AffiliateClic
     gtag('event', 'affiliate_click', { store, product, placement });
   }
 };
+
+const CLS_SCALE = 1000;
+
+interface WebVitalParams {
+  name: string;
+  value: number;
+  rating?: string;
+  id: string;
+}
+
+/**
+ * Core Web Vitals 計測値を GA4 に送信する。gtag 未ロード時は no-op。
+ * CLS は小数のため整数化(×1000)して送る(GA4 のイベント値は整数)。
+ */
+export const reportWebVital = ({ name, value, rating, id }: WebVitalParams): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const gtag = (window as unknown as { gtag?: GtagFn }).gtag;
+  if (typeof gtag === 'function') {
+    gtag('event', name, {
+      metric_id: id,
+      metric_rating: rating,
+      metric_value: value,
+      non_interaction: true,
+      value: Math.round(name === 'CLS' ? value * CLS_SCALE : value),
+    });
+  }
+};


### PR DESCRIPTION
- `app/_components/web-vitals.tsx`: Next 標準 `useReportWebVitals` で LCP/INP/CLS/FCP/TTFB 収集
- `lib/analytics`: `reportWebVital`(gtag 送信、CLS 整数化、未ロード時 no-op)
- layout body 直下に配置

新規依存ゼロ・エンドポイント未設定時は外部通信なし。検証: check 0/0・build 成功。

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)