### PR TITLE
perf: 広告枠のCLSゼロ化(高さ予約＋遅延ロード) (#150)

### DIFF
--- a/components/molecules/ad-unit/ad-unit.tsx
+++ b/components/molecules/ad-unit/ad-unit.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { adsConfig, isAdsenseEnabled } from '@/config/ads';
 import { cn } from '@/lib/utils';
 
@@ -10,6 +10,10 @@ interface AdUnitProps {
   /** 広告フォーマット (auto / fluid など) */
   format?: string;
   className?: string;
+  /** ファーストビュー外は遅延ロード(既定 true)。FV枠は false で即時ロード。 */
+  lazy?: boolean;
+  /** CLS 防止のための枠の予約高さ(px)。 */
+  minHeight?: number;
 }
 
 declare global {
@@ -18,13 +22,50 @@ declare global {
   }
 }
 
+/** 可視直前に先読みするためのマージン */
+const LAZY_ROOT_MARGIN = '200px';
+const DEFAULT_MIN_HEIGHT = 280;
+
 /**
  * Google AdSense ディスプレイ広告ユニット。
- * パブリッシャーIDまたはスロットIDが未設定の場合は何も描画しない。
+ * パブリッシャーID/スロットID未設定時は何も描画しない。
+ * CLS 防止のため枠の高さを予約し、ファーストビュー外は遅延ロードする。
  */
-export function AdUnit({ slot, format = 'auto', className }: AdUnitProps) {
+export function AdUnit({
+  slot,
+  format = 'auto',
+  className,
+  lazy = true,
+  minHeight = DEFAULT_MIN_HEIGHT,
+}: AdUnitProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shouldLoad, setShouldLoad] = useState(!lazy);
+
+  /* 遅延ロード: 可視直前に対象化する */
   useEffect(() => {
-    if (!isAdsenseEnabled || !slot) {
+    if (!isAdsenseEnabled || !slot || shouldLoad) {
+      return;
+    }
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShouldLoad(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: LAZY_ROOT_MARGIN }
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [slot, shouldLoad]);
+
+  /* ロード対象になったら広告を push する */
+  useEffect(() => {
+    if (!isAdsenseEnabled || !slot || !shouldLoad) {
       return;
     }
     try {
@@ -32,7 +73,7 @@ export function AdUnit({ slot, format = 'auto', className }: AdUnitProps) {
     } catch {
       /* AdSenseスクリプト未ロード時は無視 */
     }
-  }, [slot]);
+  }, [slot, shouldLoad]);
 
   if (!isAdsenseEnabled || !slot) {
     return null;
@@ -40,21 +81,25 @@ export function AdUnit({ slot, format = 'auto', className }: AdUnitProps) {
 
   return (
     <div
+      ref={ref}
       className={cn(
         'overflow-hidden rounded-lg bg-muted/40 shadow-xs ring-1 ring-foreground/10',
         className
       )}
+      style={{ minHeight }}
     >
       {/* 広告枠であることを示すラベル */}
       <span className="block px-3 pt-2 text-xs text-muted-foreground">広告</span>
-      <ins
-        className="adsbygoogle block px-3 pb-3"
-        style={{ display: 'block' }}
-        data-ad-client={adsConfig.adsense.clientId}
-        data-ad-slot={slot}
-        data-ad-format={format}
-        data-full-width-responsive="true"
-      />
+      {shouldLoad && (
+        <ins
+          className="adsbygoogle block px-3 pb-3"
+          style={{ display: 'block' }}
+          data-ad-client={adsConfig.adsense.clientId}
+          data-ad-slot={slot}
+          data-ad-format={format}
+          data-full-width-responsive="true"
+        />
+      )}
     </div>
   );
 }

--- a/components/molecules/banner-ad/banner-ad.tsx
+++ b/components/molecules/banner-ad/banner-ad.tsx
@@ -4,16 +4,21 @@ import { Badge } from '@/components/atoms/badge';
 import { bannerAds } from '@/config/ads';
 import { cn } from '@/lib/utils';
 
+/** CLS 防止のための枠の予約高さ(px) */
+const DEFAULT_BANNER_MIN_HEIGHT = 90;
+
 interface BannerAdProps {
   /** bannerAds 配列のインデックス */
   index?: number;
+  /** CLS 防止のための枠の予約高さ(px) */
+  minHeight?: number;
 }
 
 /**
  * A8.netなどASPが発行したバナー広告（HTMLタグ）を表示する。
  * 該当インデックスのバナーが無ければ何も描画しない。
  */
-export function BannerAd({ index = 0 }: BannerAdProps) {
+export function BannerAd({ index = 0, minHeight = DEFAULT_BANNER_MIN_HEIGHT }: BannerAdProps) {
   const banner = bannerAds[index];
   if (!banner) {
     return null;
@@ -27,7 +32,8 @@ export function BannerAd({ index = 0 }: BannerAdProps) {
         <Badge variant="outline">広告</Badge>
       </div>
       <div
-        className="flex justify-center"
+        className="flex items-center justify-center"
+        style={{ minHeight }}
         suppressHydrationWarning
         /* oxlint-disable-next-line: ASPが発行する広告タグをそのまま埋め込むため必要 */
         dangerouslySetInnerHTML={{ __html: banner.html }}

--- a/components/organisms/promo-block/promo-block.tsx
+++ b/components/organisms/promo-block/promo-block.tsx
@@ -17,7 +17,8 @@ export function PromoBlock({ placement }: PromoBlockProps) {
   if (placement === 'article-top') {
     return (
       <div className="not-prose my-6">
-        <AdUnit slot={adsConfig.adsense.slots.articleTop} />
+        {/* 記事冒頭はファーストビュー寄りのため即時ロード */}
+        <AdUnit slot={adsConfig.adsense.slots.articleTop} lazy={false} />
       </div>
     );
   }


### PR DESCRIPTION
- `ad-unit`: 枠の `min-height` を予約しロード前後の高さ変動を防止。IntersectionObserver でFV外を遅延ロード(可視直前に push)
- `promo-block`: 記事冒頭(article-top)は `lazy={false}` で即時
- `banner-ad`: 枠の `min-height` を予約

広告有効化後も CLS を実質ゼロに保つ予防的改善。検証: check 0/0・unit 248件 pass・build 成功。

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)