### PR TITLE
fix: Buy Me a Coffeeボタンが表示されない不具合を修正

### DIFF
--- a/components/molecules/buy-me-a-coffee/buy-me-a-coffee.test.tsx
+++ b/components/molecules/buy-me-a-coffee/buy-me-a-coffee.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BuyMeACoffee } from './buy-me-a-coffee';
+
+describe('BuyMeACoffee', () => {
+  it('見出しテキストを表示する', () => {
+    render(<BuyMeACoffee />);
+    expect(screen.getByText('コーヒーで応援する')).toBeInTheDocument();
+  });
+
+  it('Buy Me a Coffeeのscript要素をDOMに追加する', () => {
+    const { container } = render(<BuyMeACoffee />);
+    const script = container.querySelector('script[data-name="bmc-button"]');
+
+    expect(script).toBeInTheDocument();
+    expect(script).toHaveAttribute(
+      'src',
+      'https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js'
+    );
+    expect(script).toHaveAttribute('data-slug', 'ryoebata');
+  });
+});

--- a/components/molecules/buy-me-a-coffee/buy-me-a-coffee.tsx
+++ b/components/molecules/buy-me-a-coffee/buy-me-a-coffee.tsx
@@ -1,42 +1,67 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { Coffee } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
+const BMC_SCRIPT_SRC = 'https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js';
+
+const BMC_SCRIPT_ATTRIBUTES = {
+  'data-color': '#FFDD00',
+  'data-coffee-color': '#ffffff',
+  'data-emoji': '☕',
+  'data-font': 'Arial',
+  'data-font-color': '#000000',
+  'data-name': 'bmc-button',
+  'data-outline-color': '#000000',
+  'data-slug': 'ryoebata',
+  'data-text': 'Buy me a coffee',
+} as const;
+
 /**
- * Buy Me A Coffee Button
+ * Buy Me A Coffee のウィジェットスクリプトを埋め込む
  * @see https://buymeacoffee.com/
  *
- * <script
- *  type="text/javascript"
- *  src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
- *  data-name="bmc-button"
- *  data-slug="ryoebata"
- *  data-color="#FFDD00"
- *  data-emoji="☕"
- *  data-font="Arial"
- *  data-text="Buy me a coffee"
- *  data-outline-color="#000000"
- *  data-font-color="#000000"
- *  data-coffee-color="#ffffff"
- * ></script>
+ * 公式のscriptタグをそのままdangerouslySetInnerHTMLで挿入すると、
+ * innerHTML経由で追加されたscript要素はブラウザの仕様上実行されないため、
+ * DOM APIでscript要素を生成してマウントする
  */
-export const BuyMeACoffee = () => (
-  <div
-    className={cn(
-      'mt-12 flex flex-col items-center gap-4 rounded-xl bg-card p-6 text-center text-card-foreground shadow-xs ring-1 ring-foreground/10'
-    )}
-  >
-    <div className="flex items-center gap-2 text-muted-foreground">
-      <Coffee className="size-4" aria-hidden="true" />
-      <span className="text-sm font-medium">コーヒーで応援する</span>
-    </div>
+const useBmcWidget = (containerRef: React.RefObject<HTMLDivElement | null>) => {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = BMC_SCRIPT_SRC;
+    script.async = true;
+    for (const [name, value] of Object.entries(BMC_SCRIPT_ATTRIBUTES)) {
+      script.setAttribute(name, value);
+    }
+    container.appendChild(script);
+
+    return () => {
+      container.removeChild(script);
+    };
+  }, [containerRef]);
+};
+
+export const BuyMeACoffee = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useBmcWidget(containerRef);
+
+  return (
     <div
-      suppressHydrationWarning
-      /* Biome-ignore lint/security/noDangerouslySetInnerHtml: Buy Me a Coffee の公式スクリプト（document.write を使用するため必要） */
-      dangerouslySetInnerHTML={{
-        __html: `<script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="ryoebata" data-color="#FFDD00" data-emoji="☕" data-font="Arial" data-text="Buy me a coffee" data-outline-color="#000000" data-font-color="#000000" data-coffee-color="#ffffff"></script>`,
-      }}
-    />
-  </div>
-);
+      className={cn(
+        'mt-12 flex flex-col items-center gap-4 rounded-xl bg-card p-6 text-center text-card-foreground shadow-xs ring-1 ring-foreground/10'
+      )}
+    >
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Coffee className="size-4" aria-hidden="true" />
+        <span className="text-sm font-medium">コーヒーで応援する</span>
+      </div>
+      <div ref={containerRef} />
+    </div>
+  );
+};


### PR DESCRIPTION
## 📝 変更内容

- `/about`ページのBuy Me a Coffeeボタンが表示されない不具合を修正
- 原因: 公式の`<script>`タグを`dangerouslySetInnerHTML`で文字列として挿入していたが、`innerHTML`経由で追加された`<script>`要素はブラウザの仕様上実行されないため、ウィジェットが一度も読み込まれていなかった
- `document.createElement('script')` + `appendChild`でDOMに直接挿入する方式に変更し、実際にブラウザが実行するようにした

## 🔗 関連Issue

Closes #

## 🎯 変更の種類

- [x] 🐛 バグ修正
- [ ] ✨ 新機能
- [ ] ♻️ リファクタリング
- [ ] 📚 ドキュメント更新
- [ ] 🎨 UI/UX改善
- [ ] ⭐️ アクセシビリティ改善
- [ ] 🕐 パフォーマンス改善
- [ ] 🔍 SEO改善
- [ ] 📈 効率化
- [ ] 📚 ライブラリ更新
- [ ] ⚙️ 設定変更
- [ ] その他（以下に記載）

## 🧪 テスト

- [x] ローカル環境でテスト済み
- [x] ユニットテストを追加/更新
- [x] 既存のテストが全て通過
- [x] 手動テストを実施

### テスト内容

- `pnpm run check`（oxlint + oxfmt）: 通過
- `pnpm run test:unit`: 250件全て通過（`BuyMeACoffee`がscript要素をDOMに正しく追加することを検証するテストを追加）
- Playwrightで実際にDOMへ`<script>`要素が挿入・実行対象になることを確認（このサンドボックス環境ではcdnjs.buymeacoffee.comへの外部アクセス自体はプロキシ制限で失敗するが、本番環境ではCSPで許可済みのドメインのため問題なし）

## ✅ チェックリスト

- [x] コードがプロジェクトのスタイルガイドに準拠している
- [x] 自己レビューを実施した
- [x] 変更が既存の機能を壊していない
- [x] リンターのチェックが通過することを確認した

---
_Generated by [Claude Code](https://claude.ai/code/session_018rWefDYMV2qv3UHJD5o1Ap)_