### PR TITLE
fix: タグ別一覧ページのNot Foundと戻る遷移時の画像アニメーションを修正

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -2,6 +2,8 @@ import { revalidatePath } from 'next/cache';
 import type { NextRequest } from 'next/server';
 import { envConfig } from '@/config/env';
 import { logger } from '@/lib/logger';
+import { getAllPostsMetadata, getPostBySlug } from '@/lib/micro-cms/blog';
+import { aggregateTags } from '@/lib/tags';
 
 const UNAUTHORIZED_STATUS = 401;
 const INTERNAL_ERROR_STATUS = 500;
@@ -18,11 +20,20 @@ export const POST = async (request: NextRequest) => {
     const { slug } = await request.json();
 
     if (slug) {
-      /* 特定の記事を再検証 */
+      /* 特定の記事と、そのタグが付くタグ一覧ページを再検証する。
+         新規タグの場合は dynamicParams のデフォルト挙動でオンデマンド生成される */
       revalidatePath(`/blog/${slug}`);
+      const { metadata } = await getPostBySlug(slug);
+      for (const tag of metadata.tags ?? []) {
+        revalidatePath(`/blog/tag/${tag}`);
+      }
     } else {
-      /* ブログ一覧を再検証 */
+      /* 記事の対応関係が不明なため、ブログ一覧と全タグ一覧ページを再検証する */
       revalidatePath('/blog');
+      const posts = await getAllPostsMetadata();
+      for (const { tag } of aggregateTags(posts)) {
+        revalidatePath(`/blog/tag/${tag}`);
+      }
     }
 
     return Response.json({ now: Date.now(), revalidated: true });

--- a/app/blog/tag/[slug]/page.tsx
+++ b/app/blog/tag/[slug]/page.tsx
@@ -13,9 +13,8 @@ interface Props {
   params: Promise<{ slug: string }>;
 }
 
-/* ビルド時に全タグ分を SSG する */
-export const dynamicParams = false;
-
+/* ビルド時に既知のタグ分を SSG する。ビルド後に増えた新規タグは
+   dynamicParams のデフォルト(true)によりオンデマンドで生成しキャッシュする */
 export const generateStaticParams = async () => {
   const posts = await getAllPostsMetadata();
   /* 日本語タグもそのまま slug にする(Next.js が URL エンコードを処理) */

--- a/app/globals.css
+++ b/app/globals.css
@@ -332,3 +332,18 @@
     animation: none !important;
   }
 }
+
+/* ==============================================
+   View Transitions: root グループの既定演出を無効化
+   view-transition-name を明示指定した要素(アイキャッチ等)だけが
+   個別グループとしてモーフィングする。名前を指定していない要素は
+   すべて root グループに属し、ページ間でDOM構造・高さが大きく異なる
+   ブログ記事同士だとブラウザ標準のクロスフェード+サイズ補間が
+   目立った動き(画像が上下にスライドして見える等)を生むため、
+   root だけは演出を切って即時切り替えにする。
+   ============================================== */
+::view-transition-group(root),
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none !important;
+}

--- a/components/organisms/article-card/article-card.tsx
+++ b/components/organisms/article-card/article-card.tsx
@@ -2,8 +2,13 @@
 
 import { TagList } from '@/components/molecules/tag-list';
 import { Time } from '@/components/atoms/time/time';
+import {
+  markEyecatchViewTransition,
+  useEyecatchViewTransitionSlug,
+} from '@/lib/view-transition-slug';
 import Image from 'next/image';
 import { Link } from 'next-view-transitions';
+import { useCallback, useRef } from 'react';
 import type { CSSProperties } from 'react';
 
 const ICON_SIZE = 48;
@@ -78,6 +83,27 @@ export function ArticleCard({
 }: ArticleCardProps) {
   const linkProps = getExternalLinkProps(isExternal);
   const showDefaultIcon = !eyecatch?.url && !icon;
+  const eyecatchRef = useRef<HTMLDivElement>(null);
+
+  /* 一覧に「戻る」際、直前に見ていた記事のカードだけをモーフィング対象にする。
+     全カードに view-transition-name を付けると、対応する旧要素を持たない
+     他カードのアイキャッチまで個別の出現アニメーション対象になってしまうため、
+     sessionStorage に記録された slug と一致するカードだけ描画時に名前を付ける。 */
+  const morphSlug = useEyecatchViewTransitionSlug();
+  const viewTransitionName = slug && morphSlug === slug ? `eyecatch-${slug}` : undefined;
+
+  /* View Transition は startViewTransition() 呼び出し時点で旧DOMを同期的に
+     キャプチャするため、クリックした瞬間に DOM へ直接反映する。React の
+     再レンダーを待つと(バッチングにより)キャプチャに間に合わない。 */
+  const handleClick = useCallback(() => {
+    if (!slug) {
+      return;
+    }
+    markEyecatchViewTransition(slug);
+    if (eyecatchRef.current) {
+      eyecatchRef.current.style.viewTransitionName = `eyecatch-${slug}`;
+    }
+  }, [slug]);
 
   return (
     <article className="article-card group">
@@ -86,13 +112,15 @@ export function ArticleCard({
         className="absolute inset-0 z-0"
         aria-hidden="true"
         tabIndex={-1}
+        onClick={handleClick}
         {...linkProps}
       />
 
       <div className="relative z-10 flex flex-col">
         <div
+          ref={eyecatchRef}
           className="relative aspect-[16/9] overflow-hidden"
-          style={slug ? ({ viewTransitionName: `eyecatch-${slug}` } as CSSProperties) : undefined}
+          style={viewTransitionName ? ({ viewTransitionName } as CSSProperties) : undefined}
         >
           <CardBackground eyecatch={eyecatch} priority={priority} />
           <div className="absolute inset-0 flex items-center justify-center">
@@ -112,7 +140,7 @@ export function ArticleCard({
 
         <div className="article-card-body">
           <div className="relative z-10 flex flex-col gap-3 p-5">
-            <Link href={href} {...linkProps} className="block">
+            <Link href={href} onClick={handleClick} {...linkProps} className="block">
               <h2 className="text-base font-semibold leading-snug text-card-foreground line-clamp-2 transition-colors group-hover:text-primary">
                 {title}
               </h2>

--- a/lib/view-transition-slug.ts
+++ b/lib/view-transition-slug.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'blog:vt-eyecatch-slug';
+
+/**
+ * アイキャッチの View Transition モーフィング対象となる記事の slug を記録する。
+ * 一覧ページの該当カードだけがこの slug を見てモーフィング対象になる。
+ */
+export const markEyecatchViewTransition = (slug: string) => {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, slug);
+  } catch {
+    /* プライベートブラウジング等で sessionStorage が使えない場合は何もしない */
+  }
+};
+
+const getSnapshot = (): string | null => {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const getServerSnapshot = (): string | null => null;
+
+/* 同一タブ内での sessionStorage 更新を通知する仕組みは無い(storage イベントは他タブのみ)。
+   一覧ページが新規マウントされるタイミングでスナップショットを読めれば十分なため subscribe は no-op。 */
+const subscribe = () => () => {};
+
+export const useEyecatchViewTransitionSlug = (): string | null =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);


### PR DESCRIPTION
## 📝 変更内容

以下2件のバグを修正した。

### 1. タグ別一覧ページ(`/blog/tag/[slug]`)がNot Foundになる

原因は `dynamicParams = false` により、ビルド時に存在しなかった新規タグへのアクセスが常に404になっていたこと。加えて `/api/revalidate` が記事更新時に `/blog` と `/blog/[slug]` しかrevalidateしておらず、`/blog/tag/[slug]` 系は一切対象外だった。新しい記事に新しいタグが付くと、一覧側にはリンクが表示されるのにリンク先は再ビルドするまで生成されず、必ずNot Foundを踏む状態だった。

- `dynamicParams` の指定を削除し、デフォルトのオンデマンド生成(true)に切り替え。ビルド後に増えたタグでも初回アクセス時に生成・キャッシュされる。
- `/api/revalidate` を拡張し、記事更新時に該当タグの一覧ページも `revalidatePath` するようにした。

### 2. 詳細ページから一覧へ「戻る」際、他記事のアイキャッチ画像が上下から飛んでくる

`next-view-transitions` はブラウザバック(popstate)でも無条件にView Transition APIを発火させる。`view-transition-name` を明示指定していない要素(本文画像・関連記事カード等)はすべてブラウザ標準の `root` グループに属し、DOM構造・高さが大きく異なる記事間の遷移だとクロスフェード+サイズ補間が目立った動きを生んでいた。

さらに、全カードに一律で `view-transition-name` を付けていたため、戻る遷移時に「対応する旧DOM要素を持たない」他カードのアイキャッチまで、ブラウザにとって新規追加要素として扱われ、個別の出現アニメーション対象になっていた(カード本体とアイキャッチが別々に現れる原因)。

- `app/globals.css`: `::view-transition-group/old/new(root)` のアニメーションを無効化。`view-transition-name` を明示指定したアイキャッチのモーフィング演出自体は維持。
- `lib/view-transition-slug.ts`(新規): `sessionStorage` に「直前に見ていた記事のslug」を記録・購読するユーティリティ。読み取りは `useSyncExternalStore` による宣言的実装で、`useEffect` は使用していない。
- `components/organisms/article-card/article-card.tsx`: 一覧の全カードではなく、直前に見ていた記事に対応するカードだけに `view-transition-name` を付与するよう変更。クリック時のみ、View Transition APIの同期キャプチャに間に合わせるためイベントハンドラ内でDOMへ直接スタイルを反映する。

## 🔗 関連Issue

Closes #

## 🎯 変更の種類

- [x] 🐛 バグ修正
- [ ] ✨ 新機能
- [ ] ♻️ リファクタリング
- [ ] 📚 ドキュメント更新
- [ ] 🎨 UI/UX改善
- [ ] ⭐️ アクセシビリティ改善
- [ ] 🕐 パフォーマンス改善
- [ ] 🔍 SEO改善
- [ ] 📈 効率化
- [ ] 📚 ライブラリ更新
- [ ] ⚙️ 設定変更
- [ ] その他（以下に記載）

## 🧪 テスト

- [x] ローカル環境でテスト済み
- [x] ユニットテストを追加/更新
- [x] 既存のテストが全て通過
- [x] 手動テストを実施

### テスト内容

- `pnpm run check`(oxlint + oxfmt + tsc --noEmit): 全て成功
- `pnpm run build`: 成功。タグページは既知の24件がSSGされ、未知タグはオンデマンド生成されることを実機ビルド(`next build` → `next start`)で確認
- `pnpm run test:unit --run`: 42 files / 250 tests 全通過
- Playwright MCPによる実ブラウザ確認:
  - 未知タグへの直アクセスが404ではなく正しくコンテンツ生成されること
  - 記事詳細→一覧の「戻る」操作後、DOM上で `view-transition-name` を持つのが直前に見ていたカード1枚のみであること(他9枚は付与されないこと)を要素検証で確認

## ✅ チェックリスト

- [x] コードがプロジェクトのスタイルガイドに準拠している
- [x] 自己レビューを実施した
- [x] コメントを追加して、複雑なコードを説明した
- [ ] ドキュメントを更新した（必要に応じて）
- [x] 変更が既存の機能を壊していない
- [x] 新しい依存関係を追加した場合、その理由を説明した
- [x] ビルドが成功することを確認した
- [x] リンターのチェックが通過することを確認した

## 📋 追加情報

- View Transition周りの実装は `useEffect` を使わず、`useSyncExternalStore`(外部ストア購読の標準フック)とイベントハンドラ内の同期DOM操作のみで完結させている。マウント時に副作用を発火させる「トラッキング目的のuseEffect」パターンを避けた。

## 🔍 レビューポイント

- `lib/view-transition-slug.ts` の `subscribe` はno-op(同一タブ内のsessionStorage変更を通知する手段がないため)。一覧ページの新規マウント時にスナップショットを読めれば十分という前提に立っている。
- `article-card.tsx` の `handleClick` 内での `ref.current.style.viewTransitionName` への直接代入は、`document.startViewTransition()` が呼び出し時点で旧DOMを同期的にキャプチャする仕様上、Reactの再レンダー(バッチング)を待つと間に合わないための意図的な実装。
