### PR TITLE
SEO/AIO強化 - 構造化データ・メタデータ・sitemap・llms.txt対応

### DIFF
--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -33,7 +33,7 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
     }
 
     const postUrl = `${siteConfig.url}/blog/${post.metadata.slug}`;
-    const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl, post.contentHtml);
+    const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl);
     const content = await renderMicroCMSContent(post.contentHtml);
     const toc = extractToc(post.contentHtml);
     const relatedPosts = getRelatedPosts(post.metadata, await getAllPostsMetadata(), 3);

--- a/app/blog/[...slug]/container.tsx
+++ b/app/blog/[...slug]/container.tsx
@@ -33,7 +33,7 @@ export const BlogPostContainer = async ({ slug }: BlogPostContainerProps) => {
     }
 
     const postUrl = `${siteConfig.url}/blog/${post.metadata.slug}`;
-    const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl);
+    const articleJsonLd = generateArticleJsonLd(post.metadata, postUrl, post.contentHtml);
     const content = await renderMicroCMSContent(post.contentHtml);
     const toc = extractToc(post.contentHtml);
     const relatedPosts = getRelatedPosts(post.metadata, await getAllPostsMetadata(), 3);

--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -1,4 +1,8 @@
-import { generateMetadata as generatePageMetadata } from '@/lib/metadata';
+import {
+  generateMetadata as generatePageMetadata,
+  resolveArticleDescription,
+  resolveArticleImageUrl,
+} from '@/lib/metadata';
 import { getAllPostsMetadata, getPostBySlug } from '@/lib/micro-cms/blog';
 import type { MicroCMSContentData } from '@/lib/micro-cms/types';
 import { siteConfig } from '@/config/site';
@@ -28,26 +32,13 @@ export const generateStaticParams = async () => {
 };
 
 /*
- * 説明文を取得するヘルパー関数
- */
-const getDescription = (description: string | undefined): string => {
-  if (description) {
-    return description;
-  }
-  return siteConfig.description;
-};
-
-/*
  * メタデータを生成するヘルパー関数
  */
 const buildMetadata = (post: MicroCMSContentData): Metadata => {
   const postUrl = `${siteConfig.url}/blog/${post.metadata.slug}`;
-  const description = getDescription(post.metadata.description);
+  const description = resolveArticleDescription(post.metadata, post.contentHtml);
 
-  /* eyecatch があればそれを OG に、無ければ記事タイトル焼き込みの動的 OG を使う */
-  const ogImage =
-    post.metadata.eyecatch?.url ??
-    `${siteConfig.url}/og?title=${encodeURIComponent(post.metadata.title)}`;
+  const ogImage = resolveArticleImageUrl(post.metadata);
 
   return generatePageMetadata({
     description,

--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -1,8 +1,4 @@
-import {
-  generateMetadata as generatePageMetadata,
-  resolveArticleDescription,
-  resolveArticleImageUrl,
-} from '@/lib/metadata';
+import { generateMetadata as generatePageMetadata } from '@/lib/metadata';
 import { getAllPostsMetadata, getPostBySlug } from '@/lib/micro-cms/blog';
 import type { MicroCMSContentData } from '@/lib/micro-cms/types';
 import { siteConfig } from '@/config/site';
@@ -32,13 +28,26 @@ export const generateStaticParams = async () => {
 };
 
 /*
+ * 説明文を取得するヘルパー関数
+ */
+const getDescription = (description: string | undefined): string => {
+  if (description) {
+    return description;
+  }
+  return siteConfig.description;
+};
+
+/*
  * メタデータを生成するヘルパー関数
  */
 const buildMetadata = (post: MicroCMSContentData): Metadata => {
   const postUrl = `${siteConfig.url}/blog/${post.metadata.slug}`;
-  const description = resolveArticleDescription(post.metadata, post.contentHtml);
+  const description = getDescription(post.metadata.description);
 
-  const ogImage = resolveArticleImageUrl(post.metadata);
+  /* eyecatch があればそれを OG に、無ければ記事タイトル焼き込みの動的 OG を使う */
+  const ogImage =
+    post.metadata.eyecatch?.url ??
+    `${siteConfig.url}/og?title=${encodeURIComponent(post.metadata.title)}`;
 
   return generatePageMetadata({
     description,

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from 'react';
-import type { Metadata } from 'next';
 import { generateMetadata as generatePageMetadata } from '@/lib/metadata';
 import { siteConfig } from '@/config/site';
 
@@ -13,22 +12,11 @@ interface BlogPageProps {
 const DEFAULT_PAGE = 1;
 const BASE_RADIX = 10;
 
-/*
- * メタデータ生成(SEO対策)
- * search/tagsによる絞り込みは/blog/tag/[slug]等の正規URLと重複するコンテンツになるため
- * noindexにしてクロールバジェットの浪費を防ぐ。ページネーション(page)単体はindex許可のまま。
- */
-export const generateMetadata = async ({ searchParams }: BlogPageProps): Promise<Metadata> => {
-  const { search, tags } = await searchParams;
-  const isFiltered = Boolean(search) || Boolean(tags);
-
-  return generatePageMetadata({
-    description: `${siteConfig.name}のブログ記事一覧です。技術的な学びや日々の気づきを共有しています。`,
-    noindex: isFiltered,
-    title: 'ブログ',
-    url: `${siteConfig.url}/blog`,
-  });
-};
+export const metadata = generatePageMetadata({
+  description: `${siteConfig.name}のブログ記事一覧です。技術的な学びや日々の気づきを共有しています。`,
+  title: 'ブログ',
+  url: `${siteConfig.url}/blog`,
+});
 
 /* タグ文字列をパースしてタグ配列を返す */
 const parseTags = (tags: string | undefined): string[] => {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 import { generateMetadata as generatePageMetadata } from '@/lib/metadata';
 import { siteConfig } from '@/config/site';
 
@@ -12,11 +13,22 @@ interface BlogPageProps {
 const DEFAULT_PAGE = 1;
 const BASE_RADIX = 10;
 
-export const metadata = generatePageMetadata({
-  description: `${siteConfig.name}のブログ記事一覧です。技術的な学びや日々の気づきを共有しています。`,
-  title: 'ブログ',
-  url: `${siteConfig.url}/blog`,
-});
+/*
+ * メタデータ生成(SEO対策)
+ * search/tagsによる絞り込みは/blog/tag/[slug]等の正規URLと重複するコンテンツになるため
+ * noindexにしてクロールバジェットの浪費を防ぐ。ページネーション(page)単体はindex許可のまま。
+ */
+export const generateMetadata = async ({ searchParams }: BlogPageProps): Promise<Metadata> => {
+  const { search, tags } = await searchParams;
+  const isFiltered = Boolean(search) || Boolean(tags);
+
+  return generatePageMetadata({
+    description: `${siteConfig.name}のブログ記事一覧です。技術的な学びや日々の気づきを共有しています。`,
+    noindex: isFiltered,
+    title: 'ブログ',
+    url: `${siteConfig.url}/blog`,
+  });
+};
 
 /* タグ文字列をパースしてタグ配列を返す */
 const parseTags = (tags: string | undefined): string[] => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,6 +50,9 @@ export const metadata: Metadata = {
     description: siteConfig.description,
     title: siteConfig.name,
   },
+  ...(siteConfig.verification.google && {
+    verification: { google: siteConfig.verification.google },
+  }),
 };
 
 /**

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -16,14 +16,24 @@ const formatDescription = (description?: string): string => {
   return `Description: ${description}`;
 };
 
+/** 全記事のupdatedAt/createdAtのうち最も新しい日付をYYYY-MM-DD形式で返す(記事が無ければ現在日時) */
+const getLastUpdated = (posts: BaseContentMetadata[]): string => {
+  const latest = posts.reduce((max, post) => {
+    const timestamp = new Date(post.updatedAt || post.createdAt).getTime();
+    return Math.max(max, timestamp);
+  }, 0);
+  return new Date(latest || Date.now()).toISOString().slice(0, 10);
+};
+
 export const GET = async () => {
   const posts = await getAllPostsMetadata();
   const siteUrl = siteConfig.url;
 
   const llmsContent = `# ${siteConfig.name}
 
-## About
-${siteConfig.description}
+> ${siteConfig.description}
+
+${siteConfig.author.bio}
 
 ## URL
 ${siteUrl}
@@ -44,6 +54,9 @@ ${posts
   ${formatDescription(post.description)}`;
   })
   .join('\n')}
+
+## Last Updated
+${getLastUpdated(posts)}
 `;
 
   return new Response(llmsContent, {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,12 +1,29 @@
 import type { MetadataRoute } from 'next';
 import { siteConfig } from '@/config/site';
 
+/**
+ * AI検索(GPTBot/ClaudeBot/PerplexityBot等)・AI学習データ収集(Google-Extended/Applebot-Extended等)
+ * に使われる主要クローラー。'*'ルールで実質許可済みだが、AI引用(AIO/GEO)を歓迎する意図を
+ * 明示するため個別に許可する。
+ */
+const AI_SEARCH_USER_AGENTS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-SearchBot',
+  'PerplexityBot',
+  'Google-Extended',
+  'Applebot-Extended',
+] as const;
+
+const OPEN_ACCESS_RULE = { allow: '/', disallow: ['/api/'] };
+
 const robots = (): MetadataRoute.Robots => ({
-  rules: {
-    userAgent: '*',
-    allow: '/',
-    disallow: ['/api/'],
-  },
+  rules: [
+    { userAgent: '*', ...OPEN_ACCESS_RULE },
+    ...AI_SEARCH_USER_AGENTS.map((userAgent) => ({ userAgent, ...OPEN_ACCESS_RULE })),
+  ],
   sitemap: `${siteConfig.url}/sitemap.xml`,
   host: siteConfig.url,
 });

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -43,6 +43,7 @@ const createStaticPages = (): MetadataRoute.Sitemap => {
 const createBlogPostEntries = (posts: BaseContentMetadata[]): MetadataRoute.Sitemap =>
   posts.map((post) => ({
     changeFrequency: 'weekly',
+    ...(post.eyecatch && { images: [post.eyecatch.url] }),
     lastModified: new Date(post.updatedAt || post.createdAt),
     priority: PRIORITY_MEDIUM,
     url: `${siteConfig.url}/blog/${post.slug}`,

--- a/config/site.ts
+++ b/config/site.ts
@@ -15,4 +15,8 @@ export const siteConfig = {
   name: 'ebaryo.dev',
   repo: 'ryo-ebata/ebaryo.dev',
   url: process.env.NEXT_PUBLIC_APP_URL || 'https://ebaryo.dev',
+  /** Search Console等のサイト所有権確認コード。未設定なら該当メタタグは出力しない。 */
+  verification: {
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || '',
+  },
 };

--- a/e2e/blog-navigation.spec.ts
+++ b/e2e/blog-navigation.spec.ts
@@ -9,6 +9,21 @@ const getViewTransitionStyle = (card: Locator) =>
     return styled?.style.viewTransitionName ?? null;
   });
 
+/* 戻る遷移直後、ArticleCardのview-transition-name反映(useSyncExternalStore経由の
+   sessionStorage再評価)がDOM更新に間に合わず一瞬nullを返すことがあるため、
+   期待値に落ち着くまでポーリングして待つ。 */
+const expectEyecatchTransitionName = async (card: Locator) => {
+  await expect(async () => {
+    expect(await getViewTransitionStyle(card)).toContain('eyecatch-');
+  }).toPass();
+};
+
+const expectNoTransitionName = async (card: Locator) => {
+  await expect(async () => {
+    expect(await getViewTransitionStyle(card)).toBeNull();
+  }).toPass();
+};
+
 test.describe('Blog navigation (Cache Components / Instant Navigations)', () => {
   test('戻る遷移で直前に見ていた記事のカードだけがView Transitionのモーフィング対象になる', async ({
     page,
@@ -28,11 +43,8 @@ test.describe('Blog navigation (Cache Components / Instant Navigations)', () => 
     await page.goBack();
     await page.waitForURL('/blog');
 
-    const firstCardStyleAfterFirstVisit = await getViewTransitionStyle(firstCard);
-    const secondCardStyleAfterFirstVisit = await getViewTransitionStyle(secondCard);
-
-    expect(firstCardStyleAfterFirstVisit).toContain('eyecatch-');
-    expect(secondCardStyleAfterFirstVisit).toBeNull();
+    await expectEyecatchTransitionName(firstCard);
+    await expectNoTransitionName(secondCard);
 
     /* 続けて2件目の記事へ遷移して戻る。Activityによるルート状態保持下でも、
        1件目のカードに残っていたモーフィング対象指定が2件目に正しく
@@ -42,10 +54,7 @@ test.describe('Blog navigation (Cache Components / Instant Navigations)', () => 
     await page.goBack();
     await page.waitForURL('/blog');
 
-    const firstCardStyleAfterSecondVisit = await getViewTransitionStyle(firstCard);
-    const secondCardStyleAfterSecondVisit = await getViewTransitionStyle(secondCard);
-
-    expect(secondCardStyleAfterSecondVisit).toContain('eyecatch-');
-    expect(firstCardStyleAfterSecondVisit).toBeNull();
+    await expectEyecatchTransitionName(secondCard);
+    await expectNoTransitionName(firstCard);
   });
 });

--- a/lib/jsonld.test.ts
+++ b/lib/jsonld.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { siteConfig } from '@/config/site';
 import type { BaseContentMetadata } from './content';
 import {
   generateArticleJsonLd,
@@ -44,21 +43,11 @@ describe('generateArticleJsonLd', () => {
     expect(result.image).toBe('https://example.com/image.jpg');
   });
 
-  it('eyecatchがない場合は動的OG画像にフォールバックする', () => {
+  it('eyecatchがない場合imageを含まない', () => {
     const metadata = createMockMetadata();
     const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
 
-    expect(result.image).toBe(`${siteConfig.url}/og?title=${encodeURIComponent(metadata.title)}`);
-  });
-
-  it('mainEntityOfPageを含む', () => {
-    const metadata = createMockMetadata();
-    const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
-
-    expect(result.mainEntityOfPage).toEqual({
-      '@type': 'WebPage',
-      '@id': 'https://example.com/blog/test',
-    });
+    expect(result.image).toBeUndefined();
   });
 
   it('tagsがある場合keywordsを含む', () => {
@@ -81,8 +70,7 @@ describe('generateArticleJsonLd', () => {
 
     expect(result.author).toEqual({
       '@type': 'Person',
-      description: expect.any(String),
-      name: siteConfig.author.name,
+      name: expect.any(String),
       url: expect.any(String),
       sameAs: expect.any(Array),
     });
@@ -91,24 +79,6 @@ describe('generateArticleJsonLd', () => {
       name: expect.any(String),
       url: expect.any(String),
     });
-  });
-
-  it('descriptionが未入力の場合contentHtmlの本文冒頭にフォールバックする', () => {
-    const metadata = createMockMetadata({ description: undefined });
-    const result = generateArticleJsonLd(
-      metadata,
-      'https://example.com/blog/test',
-      '<p>本文の冒頭テキスト</p>'
-    );
-
-    expect(result.description).toBe('本文の冒頭テキスト');
-  });
-
-  it('descriptionもcontentHtmlも無い場合サイト全体の説明文にフォールバックする', () => {
-    const metadata = createMockMetadata({ description: undefined });
-    const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
-
-    expect(result.description).toBe(siteConfig.description);
   });
 });
 

--- a/lib/jsonld.test.ts
+++ b/lib/jsonld.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { siteConfig } from '@/config/site';
 import type { BaseContentMetadata } from './content';
 import {
   generateArticleJsonLd,
@@ -43,11 +44,23 @@ describe('generateArticleJsonLd', () => {
     expect(result.image).toBe('https://example.com/image.jpg');
   });
 
-  it('eyecatchがない場合imageを含まない', () => {
+  it('eyecatchがない場合は動的OG画像にフォールバックする', () => {
     const metadata = createMockMetadata();
     const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
 
-    expect(result.image).toBeUndefined();
+    expect(result.image).toBe(
+      `${siteConfig.url}/og?title=${encodeURIComponent(metadata.title)}`
+    );
+  });
+
+  it('mainEntityOfPageを含む', () => {
+    const metadata = createMockMetadata();
+    const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
+
+    expect(result.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': 'https://example.com/blog/test',
+    });
   });
 
   it('tagsがある場合keywordsを含む', () => {
@@ -70,7 +83,8 @@ describe('generateArticleJsonLd', () => {
 
     expect(result.author).toEqual({
       '@type': 'Person',
-      name: expect.any(String),
+      description: expect.any(String),
+      name: siteConfig.author.name,
       url: expect.any(String),
       sameAs: expect.any(Array),
     });
@@ -79,6 +93,24 @@ describe('generateArticleJsonLd', () => {
       name: expect.any(String),
       url: expect.any(String),
     });
+  });
+
+  it('descriptionが未入力の場合contentHtmlの本文冒頭にフォールバックする', () => {
+    const metadata = createMockMetadata({ description: undefined });
+    const result = generateArticleJsonLd(
+      metadata,
+      'https://example.com/blog/test',
+      '<p>本文の冒頭テキスト</p>'
+    );
+
+    expect(result.description).toBe('本文の冒頭テキスト');
+  });
+
+  it('descriptionもcontentHtmlも無い場合サイト全体の説明文にフォールバックする', () => {
+    const metadata = createMockMetadata({ description: undefined });
+    const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
+
+    expect(result.description).toBe(siteConfig.description);
   });
 });
 

--- a/lib/jsonld.test.ts
+++ b/lib/jsonld.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { siteConfig } from '@/config/site';
 import type { BaseContentMetadata } from './content';
 import {
   generateArticleJsonLd,
@@ -43,11 +44,21 @@ describe('generateArticleJsonLd', () => {
     expect(result.image).toBe('https://example.com/image.jpg');
   });
 
-  it('eyecatchがない場合imageを含まない', () => {
+  it('eyecatchがない場合は動的OG画像にフォールバックする', () => {
     const metadata = createMockMetadata();
     const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
 
-    expect(result.image).toBeUndefined();
+    expect(result.image).toBe(`${siteConfig.url}/og?title=${encodeURIComponent(metadata.title)}`);
+  });
+
+  it('mainEntityOfPageを含む', () => {
+    const metadata = createMockMetadata();
+    const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
+
+    expect(result.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': 'https://example.com/blog/test',
+    });
   });
 
   it('tagsがある場合keywordsを含む', () => {
@@ -70,7 +81,8 @@ describe('generateArticleJsonLd', () => {
 
     expect(result.author).toEqual({
       '@type': 'Person',
-      name: expect.any(String),
+      description: expect.any(String),
+      name: siteConfig.author.name,
       url: expect.any(String),
       sameAs: expect.any(Array),
     });
@@ -79,6 +91,24 @@ describe('generateArticleJsonLd', () => {
       name: expect.any(String),
       url: expect.any(String),
     });
+  });
+
+  it('descriptionが未入力の場合contentHtmlの本文冒頭にフォールバックする', () => {
+    const metadata = createMockMetadata({ description: undefined });
+    const result = generateArticleJsonLd(
+      metadata,
+      'https://example.com/blog/test',
+      '<p>本文の冒頭テキスト</p>'
+    );
+
+    expect(result.description).toBe('本文の冒頭テキスト');
+  });
+
+  it('descriptionもcontentHtmlも無い場合サイト全体の説明文にフォールバックする', () => {
+    const metadata = createMockMetadata({ description: undefined });
+    const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
+
+    expect(result.description).toBe(siteConfig.description);
   });
 });
 

--- a/lib/jsonld.test.ts
+++ b/lib/jsonld.test.ts
@@ -48,9 +48,7 @@ describe('generateArticleJsonLd', () => {
     const metadata = createMockMetadata();
     const result = generateArticleJsonLd(metadata, 'https://example.com/blog/test');
 
-    expect(result.image).toBe(
-      `${siteConfig.url}/og?title=${encodeURIComponent(metadata.title)}`
-    );
+    expect(result.image).toBe(`${siteConfig.url}/og?title=${encodeURIComponent(metadata.title)}`);
   });
 
   it('mainEntityOfPageを含む', () => {

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -1,5 +1,6 @@
 import type { BaseContentMetadata } from './content';
 import { siteConfig } from '@/config/site';
+import { resolveArticleDescription, resolveArticleImageUrl } from './metadata';
 
 const EMPTY_LENGTH = 0;
 
@@ -8,21 +9,28 @@ const EMPTY_LENGTH = 0;
  */
 export const generateArticleJsonLd = (
   metadata: BaseContentMetadata,
-  url: string
+  url: string,
+  contentHtml?: string
 ): Record<string, unknown> => {
   const jsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     author: {
       '@type': 'Person',
-      name: siteConfig.name,
+      description: siteConfig.author.bio,
+      name: siteConfig.author.name,
       url: `${siteConfig.url}/about`,
       sameAs: collectSocialLinks(),
     },
     dateModified: metadata.updatedAt || metadata.createdAt,
     datePublished: metadata.createdAt,
-    description: metadata.description || siteConfig.description,
+    description: resolveArticleDescription(metadata, contentHtml),
     headline: metadata.title,
+    image: resolveArticleImageUrl(metadata),
+    mainEntityOfPage: {
+      '@id': url,
+      '@type': 'WebPage',
+    },
     publisher: {
       '@type': 'Organization',
       name: siteConfig.name,
@@ -30,10 +38,6 @@ export const generateArticleJsonLd = (
     },
     url,
   };
-
-  if (metadata.eyecatch) {
-    jsonLd.image = metadata.eyecatch.url;
-  }
 
   /* タグがある場合はkeywordsに追加 */
   if (metadata.tags && metadata.tags.length > EMPTY_LENGTH) {

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -1,6 +1,5 @@
 import type { BaseContentMetadata } from './content';
 import { siteConfig } from '@/config/site';
-import { resolveArticleDescription, resolveArticleImageUrl } from './metadata';
 
 const EMPTY_LENGTH = 0;
 
@@ -9,28 +8,21 @@ const EMPTY_LENGTH = 0;
  */
 export const generateArticleJsonLd = (
   metadata: BaseContentMetadata,
-  url: string,
-  contentHtml?: string
+  url: string
 ): Record<string, unknown> => {
   const jsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     author: {
       '@type': 'Person',
-      description: siteConfig.author.bio,
-      name: siteConfig.author.name,
+      name: siteConfig.name,
       url: `${siteConfig.url}/about`,
       sameAs: collectSocialLinks(),
     },
     dateModified: metadata.updatedAt || metadata.createdAt,
     datePublished: metadata.createdAt,
-    description: resolveArticleDescription(metadata, contentHtml),
+    description: metadata.description || siteConfig.description,
     headline: metadata.title,
-    image: resolveArticleImageUrl(metadata),
-    mainEntityOfPage: {
-      '@id': url,
-      '@type': 'WebPage',
-    },
     publisher: {
       '@type': 'Organization',
       name: siteConfig.name,
@@ -38,6 +30,10 @@ export const generateArticleJsonLd = (
     },
     url,
   };
+
+  if (metadata.eyecatch) {
+    jsonLd.image = metadata.eyecatch.url;
+  }
 
   /* タグがある場合はkeywordsに追加 */
   if (metadata.tags && metadata.tags.length > EMPTY_LENGTH) {

--- a/lib/metadata.test.ts
+++ b/lib/metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { generateMetadata } from './metadata';
+import { siteConfig } from '@/config/site';
+import { generateMetadata, resolveArticleDescription } from './metadata';
 
 describe('generateMetadata', () => {
   describe('websiteタイプ', () => {
@@ -128,5 +129,28 @@ describe('generateMetadata', () => {
         url: expect.stringContaining('/custom-image.jpg'),
       });
     });
+  });
+});
+
+describe('resolveArticleDescription', () => {
+  it('descriptionがあればそれをそのまま使う', () => {
+    const result = resolveArticleDescription({ description: '記事の説明' }, '<p>本文</p>');
+
+    expect(result).toBe('記事の説明');
+  });
+
+  it('description未入力の場合contentHtmlの本文冒頭から抽出する', () => {
+    const result = resolveArticleDescription(
+      { description: undefined },
+      '<p>本文の冒頭テキスト</p><pre><code>除外対象</code></pre>'
+    );
+
+    expect(result).toBe('本文の冒頭テキスト');
+  });
+
+  it('description未入力かつcontentHtmlも無い場合サイト全体の説明文にフォールバックする', () => {
+    const result = resolveArticleDescription({ description: undefined });
+
+    expect(result).toBe(siteConfig.description);
   });
 });

--- a/lib/metadata.test.ts
+++ b/lib/metadata.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { siteConfig } from '@/config/site';
-import { generateMetadata, resolveArticleDescription } from './metadata';
+import { generateMetadata } from './metadata';
 
 describe('generateMetadata', () => {
   describe('websiteタイプ', () => {
@@ -129,28 +128,5 @@ describe('generateMetadata', () => {
         url: expect.stringContaining('/custom-image.jpg'),
       });
     });
-  });
-});
-
-describe('resolveArticleDescription', () => {
-  it('descriptionがあればそれをそのまま使う', () => {
-    const result = resolveArticleDescription({ description: '記事の説明' }, '<p>本文</p>');
-
-    expect(result).toBe('記事の説明');
-  });
-
-  it('description未入力の場合contentHtmlの本文冒頭から抽出する', () => {
-    const result = resolveArticleDescription(
-      { description: undefined },
-      '<p>本文の冒頭テキスト</p><pre><code>除外対象</code></pre>'
-    );
-
-    expect(result).toBe('本文の冒頭テキスト');
-  });
-
-  it('description未入力かつcontentHtmlも無い場合サイト全体の説明文にフォールバックする', () => {
-    const result = resolveArticleDescription({ description: undefined });
-
-    expect(result).toBe(siteConfig.description);
   });
 });

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,13 +1,18 @@
 import type { Metadata } from 'next';
 import { siteConfig } from '@/config/site';
+import { extractPlainText } from './micro-cms/count-characters';
+import type { BaseContentMetadata } from './content';
 
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
+const META_DESCRIPTION_LENGTH = 120;
 
 interface BaseMetadataParams {
   description: string;
   image?: string;
   imageAlt?: string;
+  /** trueの場合、検索エンジンにnoindex,followを指示する(絞り込み結果など重複コンテンツ向け) */
+  noindex?: boolean;
   title: string;
   type?: 'article' | 'website';
   url?: string;
@@ -26,17 +31,44 @@ const isArticleMetadata = (params: MetadataParams): params is ArticleMetadataPar
   params.type === 'article';
 
 /**
+ * 相対パスを絶対URLに変換する。すでに絶対URLならそのまま返す。
+ */
+const toAbsoluteUrl = (path: string): string =>
+  path.startsWith('http') ? path : `${siteConfig.url}${path}`;
+
+/**
  * OGP画像のURLを生成
  * image未指定時はundefinedを返し、opengraph-image.tsxにフォールバックさせる
  */
-const getOgImageUrl = (image?: string): string | undefined => {
-  if (image) {
-    if (image.startsWith('http')) {
-      return image;
-    }
-    return `${siteConfig.url}${image}`;
+const getOgImageUrl = (image?: string): string | undefined =>
+  image ? toAbsoluteUrl(image) : undefined;
+
+/**
+ * 記事のOGP/構造化データ用画像URLを解決する。
+ * eyecatchがあればそれを、無ければ記事タイトル焼き込みの動的OG画像を使う。
+ */
+export const resolveArticleImageUrl = (
+  metadata: Pick<BaseContentMetadata, 'eyecatch' | 'title'>
+): string =>
+  toAbsoluteUrl(metadata.eyecatch?.url ?? `/og?title=${encodeURIComponent(metadata.title)}`);
+
+/**
+ * 記事のOGP/構造化データ用descriptionを解決する。
+ * 未入力ならcontentHtmlの本文冒頭から抽出し、それも無ければサイト全体の説明文にフォールバックする。
+ * (未入力記事が全てサイト説明文になり検索結果で重複スニペットになるのを防ぐ)
+ */
+export const resolveArticleDescription = (
+  metadata: Pick<BaseContentMetadata, 'description'>,
+  contentHtml?: string
+): string => {
+  if (metadata.description) {
+    return metadata.description;
   }
-  return undefined;
+  const plainText = contentHtml ? extractPlainText(contentHtml) : '';
+  if (plainText) {
+    return plainText.slice(0, META_DESCRIPTION_LENGTH);
+  }
+  return siteConfig.description;
 };
 
 /**
@@ -53,7 +85,7 @@ const getOgTitle = (title: string, type: 'article' | 'website'): string => {
  * 共通のメタデータを生成
  */
 export const generateMetadata = (params: MetadataParams): Metadata => {
-  const { description, image, imageAlt, title, type = 'website', url } = params;
+  const { description, image, imageAlt, noindex, title, type = 'website', url } = params;
 
   const ogImageUrl = getOgImageUrl(image);
   const pageUrl = url || siteConfig.url;
@@ -69,6 +101,7 @@ export const generateMetadata = (params: MetadataParams): Metadata => {
       },
     },
     description,
+    ...(noindex && { robots: { follow: true, index: false } }),
     openGraph: {
       description,
       ...(ogImageUrl && {

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,11 +1,8 @@
 import type { Metadata } from 'next';
 import { siteConfig } from '@/config/site';
-import { extractPlainText } from './micro-cms/count-characters';
-import type { BaseContentMetadata } from './content';
 
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
-const META_DESCRIPTION_LENGTH = 120;
 
 interface BaseMetadataParams {
   description: string;
@@ -31,44 +28,17 @@ const isArticleMetadata = (params: MetadataParams): params is ArticleMetadataPar
   params.type === 'article';
 
 /**
- * 相対パスを絶対URLに変換する。すでに絶対URLならそのまま返す。
- */
-const toAbsoluteUrl = (path: string): string =>
-  path.startsWith('http') ? path : `${siteConfig.url}${path}`;
-
-/**
  * OGP画像のURLを生成
  * image未指定時はundefinedを返し、opengraph-image.tsxにフォールバックさせる
  */
-const getOgImageUrl = (image?: string): string | undefined =>
-  image ? toAbsoluteUrl(image) : undefined;
-
-/**
- * 記事のOGP/構造化データ用画像URLを解決する。
- * eyecatchがあればそれを、無ければ記事タイトル焼き込みの動的OG画像を使う。
- */
-export const resolveArticleImageUrl = (
-  metadata: Pick<BaseContentMetadata, 'eyecatch' | 'title'>
-): string =>
-  toAbsoluteUrl(metadata.eyecatch?.url ?? `/og?title=${encodeURIComponent(metadata.title)}`);
-
-/**
- * 記事のOGP/構造化データ用descriptionを解決する。
- * 未入力ならcontentHtmlの本文冒頭から抽出し、それも無ければサイト全体の説明文にフォールバックする。
- * (未入力記事が全てサイト説明文になり検索結果で重複スニペットになるのを防ぐ)
- */
-export const resolveArticleDescription = (
-  metadata: Pick<BaseContentMetadata, 'description'>,
-  contentHtml?: string
-): string => {
-  if (metadata.description) {
-    return metadata.description;
+const getOgImageUrl = (image?: string): string | undefined => {
+  if (image) {
+    if (image.startsWith('http')) {
+      return image;
+    }
+    return `${siteConfig.url}${image}`;
   }
-  const plainText = contentHtml ? extractPlainText(contentHtml) : '';
-  if (plainText) {
-    return plainText.slice(0, META_DESCRIPTION_LENGTH);
-  }
-  return siteConfig.description;
+  return undefined;
 };
 
 /**

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,18 +1,13 @@
 import type { Metadata } from 'next';
 import { siteConfig } from '@/config/site';
-import { extractPlainText } from './micro-cms/count-characters';
-import type { BaseContentMetadata } from './content';
 
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
-const META_DESCRIPTION_LENGTH = 120;
 
 interface BaseMetadataParams {
   description: string;
   image?: string;
   imageAlt?: string;
-  /** trueの場合、検索エンジンにnoindex,followを指示する(絞り込み結果など重複コンテンツ向け) */
-  noindex?: boolean;
   title: string;
   type?: 'article' | 'website';
   url?: string;
@@ -31,44 +26,17 @@ const isArticleMetadata = (params: MetadataParams): params is ArticleMetadataPar
   params.type === 'article';
 
 /**
- * 相対パスを絶対URLに変換する。すでに絶対URLならそのまま返す。
- */
-const toAbsoluteUrl = (path: string): string =>
-  path.startsWith('http') ? path : `${siteConfig.url}${path}`;
-
-/**
  * OGP画像のURLを生成
  * image未指定時はundefinedを返し、opengraph-image.tsxにフォールバックさせる
  */
-const getOgImageUrl = (image?: string): string | undefined =>
-  image ? toAbsoluteUrl(image) : undefined;
-
-/**
- * 記事のOGP/構造化データ用画像URLを解決する。
- * eyecatchがあればそれを、無ければ記事タイトル焼き込みの動的OG画像を使う。
- */
-export const resolveArticleImageUrl = (
-  metadata: Pick<BaseContentMetadata, 'eyecatch' | 'title'>
-): string =>
-  toAbsoluteUrl(metadata.eyecatch?.url ?? `/og?title=${encodeURIComponent(metadata.title)}`);
-
-/**
- * 記事のOGP/構造化データ用descriptionを解決する。
- * 未入力ならcontentHtmlの本文冒頭から抽出し、それも無ければサイト全体の説明文にフォールバックする。
- * (未入力記事が全てサイト説明文になり検索結果で重複スニペットになるのを防ぐ)
- */
-export const resolveArticleDescription = (
-  metadata: Pick<BaseContentMetadata, 'description'>,
-  contentHtml?: string
-): string => {
-  if (metadata.description) {
-    return metadata.description;
+const getOgImageUrl = (image?: string): string | undefined => {
+  if (image) {
+    if (image.startsWith('http')) {
+      return image;
+    }
+    return `${siteConfig.url}${image}`;
   }
-  const plainText = contentHtml ? extractPlainText(contentHtml) : '';
-  if (plainText) {
-    return plainText.slice(0, META_DESCRIPTION_LENGTH);
-  }
-  return siteConfig.description;
+  return undefined;
 };
 
 /**
@@ -85,7 +53,7 @@ const getOgTitle = (title: string, type: 'article' | 'website'): string => {
  * 共通のメタデータを生成
  */
 export const generateMetadata = (params: MetadataParams): Metadata => {
-  const { description, image, imageAlt, noindex, title, type = 'website', url } = params;
+  const { description, image, imageAlt, title, type = 'website', url } = params;
 
   const ogImageUrl = getOgImageUrl(image);
   const pageUrl = url || siteConfig.url;
@@ -101,7 +69,6 @@ export const generateMetadata = (params: MetadataParams): Metadata => {
       },
     },
     description,
-    ...(noindex && { robots: { follow: true, index: false } }),
     openGraph: {
       description,
       ...(ogImageUrl && {

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,8 +1,11 @@
 import type { Metadata } from 'next';
 import { siteConfig } from '@/config/site';
+import { extractPlainText } from './micro-cms/count-characters';
+import type { BaseContentMetadata } from './content';
 
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
+const META_DESCRIPTION_LENGTH = 120;
 
 interface BaseMetadataParams {
   description: string;
@@ -28,17 +31,44 @@ const isArticleMetadata = (params: MetadataParams): params is ArticleMetadataPar
   params.type === 'article';
 
 /**
+ * 相対パスを絶対URLに変換する。すでに絶対URLならそのまま返す。
+ */
+const toAbsoluteUrl = (path: string): string =>
+  path.startsWith('http') ? path : `${siteConfig.url}${path}`;
+
+/**
  * OGP画像のURLを生成
  * image未指定時はundefinedを返し、opengraph-image.tsxにフォールバックさせる
  */
-const getOgImageUrl = (image?: string): string | undefined => {
-  if (image) {
-    if (image.startsWith('http')) {
-      return image;
-    }
-    return `${siteConfig.url}${image}`;
+const getOgImageUrl = (image?: string): string | undefined =>
+  image ? toAbsoluteUrl(image) : undefined;
+
+/**
+ * 記事のOGP/構造化データ用画像URLを解決する。
+ * eyecatchがあればそれを、無ければ記事タイトル焼き込みの動的OG画像を使う。
+ */
+export const resolveArticleImageUrl = (
+  metadata: Pick<BaseContentMetadata, 'eyecatch' | 'title'>
+): string =>
+  toAbsoluteUrl(metadata.eyecatch?.url ?? `/og?title=${encodeURIComponent(metadata.title)}`);
+
+/**
+ * 記事のOGP/構造化データ用descriptionを解決する。
+ * 未入力ならcontentHtmlの本文冒頭から抽出し、それも無ければサイト全体の説明文にフォールバックする。
+ * (未入力記事が全てサイト説明文になり検索結果で重複スニペットになるのを防ぐ)
+ */
+export const resolveArticleDescription = (
+  metadata: Pick<BaseContentMetadata, 'description'>,
+  contentHtml?: string
+): string => {
+  if (metadata.description) {
+    return metadata.description;
   }
-  return undefined;
+  const plainText = contentHtml ? extractPlainText(contentHtml) : '';
+  if (plainText) {
+    return plainText.slice(0, META_DESCRIPTION_LENGTH);
+  }
+  return siteConfig.description;
 };
 
 /**

--- a/lib/micro-cms/count-characters.ts
+++ b/lib/micro-cms/count-characters.ts
@@ -1,4 +1,3 @@
-import { cache } from 'react';
 import { unified } from 'unified';
 import rehypeParse from 'rehype-parse';
 import { visit } from 'unist-util-visit';
@@ -29,17 +28,13 @@ const extractTextFromHast = (tree: Root): string => {
   return texts.join('');
 };
 
-/**
- * HTML から pre/code を除いたプレーンテキストを抽出する(空白正規化済み)。
- * 同一リクエスト内でmetadata生成とJSON-LD生成が同じcontentHtmlを解析するため、
- * cache()でリクエストスコープのメモ化を行い重複パースを避ける。
- */
-export const extractPlainText = cache((html: string): string => {
+/** HTML から pre/code を除いたプレーンテキストを抽出する(空白正規化済み)。 */
+export const extractPlainText = (html: string): string => {
   if (!html) {
     return '';
   }
   const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
   return extractTextFromHast(tree).replace(/\s+/g, ' ').trim();
-});
+};
 
 export const countHtmlCharacters = (html: string): number => extractPlainText(html).length;

--- a/lib/micro-cms/count-characters.ts
+++ b/lib/micro-cms/count-characters.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { unified } from 'unified';
 import rehypeParse from 'rehype-parse';
 import { visit } from 'unist-util-visit';
@@ -28,13 +29,17 @@ const extractTextFromHast = (tree: Root): string => {
   return texts.join('');
 };
 
-/** HTML から pre/code を除いたプレーンテキストを抽出する(空白正規化済み)。 */
-export const extractPlainText = (html: string): string => {
+/**
+ * HTML から pre/code を除いたプレーンテキストを抽出する(空白正規化済み)。
+ * 同一リクエスト内でmetadata生成とJSON-LD生成が同じcontentHtmlを解析するため、
+ * cache()でリクエストスコープのメモ化を行い重複パースを避ける。
+ */
+export const extractPlainText = cache((html: string): string => {
   if (!html) {
     return '';
   }
   const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
   return extractTextFromHast(tree).replace(/\s+/g, ' ').trim();
-};
+});
 
 export const countHtmlCharacters = (html: string): number => extractPlainText(html).length;


### PR DESCRIPTION
## Summary
- BlogPostingのJSON-LDに`mainEntityOfPage`・著者bio・画像フォールバックを追加し、OGPメタデータと解決ロジックを共通化(`resolveArticleDescription`/`resolveArticleImageUrl`)
- 記事description未入力時は本文冒頭から自動抽出してフォールバックし、検索結果での重複スニペットを防止
- サイトマップに画像拡張(`image:image`)を追加、検索/タグ絞り込みURL(`/blog?search=`, `?tags=`)をnoindex化
- Google Search Console verificationに対応(`NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`環境変数、未設定時は出力なし)
- `llms.txt`を標準フォーマット(blockquote要約 + Last Updated)に修正、`robots.txt`で主要AI検索/学習クローラー(GPTBot, ClaudeBot, PerplexityBot, Google-Extended等)を明示許可
- 記事本文の重複HTML解析を`cache()`で解消するなど、`/simplify`によるコード品質改善を実施

## Test plan
- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test:unit` 全256件通過
- [x] devサーバーで `/sitemap.xml`・`/robots.txt`・`/llms.txt`・`/blog?search=`のrobotsメタタグの実出力を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
