### PR TITLE
fix: ブログ記事内テーブルがスマホ表示で画面幅を超える不具合を修正

### DIFF
--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -4,5 +4,6 @@ export { CodeBlock } from './code-block';
 export { EmptyState } from './empty-state/empty-state';
 export { MdxBlockquote } from './mdx-blockquote';
 export { MdxH1, MdxH2, MdxH3, MdxH4, MdxH5, MdxH6, MdxHeading } from './mdx-heading';
+export { MdxTable } from './mdx-table';
 export { Pagination } from './pagination/pagination';
 export { TagList } from './tag-list';

--- a/components/molecules/mdx-table/index.ts
+++ b/components/molecules/mdx-table/index.ts
@@ -1,0 +1,2 @@
+export { MdxTable } from './mdx-table';
+export type { MdxTableProps } from './types';

--- a/components/molecules/mdx-table/mdx-table.tsx
+++ b/components/molecules/mdx-table/mdx-table.tsx
@@ -1,0 +1,8 @@
+import type { MdxTableProps } from './types';
+
+/* スマホ表示で列数の多い表がビューポート幅を超えないよう、横スクロール可能なコンテナで囲む */
+export const MdxTable = (props: MdxTableProps) => (
+  <div className="w-full overflow-x-auto">
+    <table {...props} />
+  </div>
+);

--- a/components/molecules/mdx-table/types.ts
+++ b/components/molecules/mdx-table/types.ts
@@ -1,0 +1,3 @@
+import type { TableHTMLAttributes } from 'react';
+
+export type MdxTableProps = TableHTMLAttributes<HTMLTableElement>;

--- a/lib/micro-cms/content-renderer.test.tsx
+++ b/lib/micro-cms/content-renderer.test.tsx
@@ -76,4 +76,13 @@ describe('renderMicroCMSContent', () => {
 
     expect(markup).toContain('amazon.co.jp/dp/B000000000');
   });
+
+  it('tableがスマホ表示でも幅を超えないよう横スクロール可能なコンテナで囲まれる', async () => {
+    const html = '<table><tbody><tr><td>セル</td></tr></tbody></table>';
+    const result = await renderMicroCMSContent(html);
+    const markup = renderToStaticMarkup(result);
+
+    expect(markup).toContain('overflow-x-auto');
+    expect(markup).toContain('セル');
+  });
 });

--- a/lib/micro-cms/content-renderer.tsx
+++ b/lib/micro-cms/content-renderer.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 
 import { MdxBlockquote } from '@/components/molecules/mdx-blockquote';
 import { MdxH1, MdxH2, MdxH3, MdxH4, MdxH5, MdxH6 } from '@/components/molecules/mdx-heading';
+import { MdxTable } from '@/components/molecules/mdx-table';
 import { ContentLinkCard as ContentLinkCardAsync } from '@/components/organisms/content-link-card/content-link-card';
 import { ProductLink } from '@/components/organisms/product-link/product-link';
 
@@ -50,6 +51,7 @@ const components = {
   h4: MdxH4,
   h5: MdxH5,
   h6: MdxH6,
+  table: MdxTable,
 };
 
 export const renderMicroCMSContent = async (html: string): Promise<ReactNode> => {


### PR DESCRIPTION
## 📝 変更内容

- ブログ記事(microCMS)本文内の`<table>`がスマホ表示で画面幅を超えてページ全体が横スクロールしてしまう不具合を修正
- `lib/micro-cms/content-renderer.tsx`のHTML→React変換コンポーネントマッピングに`table`を追加
- `<table>`を`overflow-x-auto`なコンテナで囲む`MdxTable`コンポーネント(`components/molecules/mdx-table/`)を新規作成し、列数の多い表でもページ全体ではなく表自体だけが横スクロールするようにした

## 🔗 関連Issue

Closes #

## 🎯 変更の種類

- [x] 🐛 バグ修正
- [ ] ✨ 新機能
- [ ] ♻️ リファクタリング
- [ ] 📚 ドキュメント更新
- [ ] 🎨 UI/UX改善
- [ ] ⭐️ アクセシビリティ改善
- [ ] 🕐 パフォーマンス改善
- [ ] 🔍 SEO改善
- [ ] 📈 効率化
- [ ] 📚 ライブラリ更新
- [ ] ⚙️ 設定変更
- [ ] その他（以下に記載）

## 🧪 テスト

- [x] ローカル環境でテスト済み
- [x] ユニットテストを追加/更新
- [x] 既存のテストが全て通過
- [x] 手動テストを実施

### テスト内容

- `pnpm run check`（oxlint + oxfmt + tsc）: 通過
- `pnpm run test:unit`: 257件全て通過（tableがoverflow-x-autoコンテナで囲まれることを検証するテストを追加）
- Playwrightで15列の表を使い、375px幅での挙動を修正前後で比較検証
  - 修正前: ページの`scrollWidth`が494pxまで膨張（ページ全体がはみ出す）
  - 修正後: ページの`scrollWidth`は375pxのまま（表の中だけがスクロール可能）

## ✅ チェックリスト

- [x] コードがプロジェクトのスタイルガイドに準拠している
- [x] 自己レビューを実施した
- [x] 変更が既存の機能を壊していない
- [x] リンターのチェックが通過することを確認した

---
_Generated by [Claude Code](https://claude.ai/code/session_018rWefDYMV2qv3UHJD5o1Ap)_