### PR TITLE
perf: 画像読み込みを最適化

### DIFF
--- a/app/blog/presenter.tsx
+++ b/app/blog/presenter.tsx
@@ -123,7 +123,7 @@ const FilterSection = ({
   <div className="space-y-6">
     <TagFilterList onTagToggle={onTagToggle} selectedTags={selectedTags} tags={tagCounts} />
     <SearchInput onChange={onSearchChange} value={searchQuery} />
-    <PostList posts={posts} />
+    <PostList posts={posts} prioritizeFirst />
     <EmptyResultMessage hasFilters={hasFilters} isEmpty={isEmpty} />
     <Pagination basePath="/blog" currentPage={currentPage} totalPages={totalPages} />
   </div>

--- a/app/blog/tag/[slug]/page.tsx
+++ b/app/blog/tag/[slug]/page.tsx
@@ -47,7 +47,7 @@ const TagPage = async ({ params }: Props) => {
           <h1 className="scroll-m-20 text-3xl font-bold text-foreground">{slug}</h1>
           <p className="text-sm text-muted-foreground">{filtered.length} 件の記事</p>
         </div>
-        <PostList posts={filtered} />
+        <PostList posts={filtered} prioritizeFirst />
         <div className="text-end">
           <BackLink href="/blog" label="ブログ一覧に戻る" />
         </div>

--- a/app/presenter.tsx
+++ b/app/presenter.tsx
@@ -72,7 +72,7 @@ function PostsSection({ posts }: PostsSectionProps) {
         <SectionHeading>最新記事</SectionHeading>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        {posts.map((post) => (
+        {posts.map((post, index) => (
           <ArticleCard
             key={post.slug}
             date={post.createdAt}
@@ -81,6 +81,7 @@ function PostsSection({ posts }: PostsSectionProps) {
             href={`/blog/${post.slug}`}
             slug={post.slug}
             isExternal={false}
+            priority={index === 0}
             tags={post.tags}
             title={post.title}
           />

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -4,6 +4,7 @@ export { CodeBlock } from './code-block';
 export { EmptyState } from './empty-state/empty-state';
 export { MdxBlockquote } from './mdx-blockquote';
 export { MdxH1, MdxH2, MdxH3, MdxH4, MdxH5, MdxH6, MdxHeading } from './mdx-heading';
+export { MdxImage } from './mdx-image';
 export { MdxTable } from './mdx-table';
 export { Pagination } from './pagination/pagination';
 export { TagList } from './tag-list';

--- a/components/molecules/mdx-image/index.ts
+++ b/components/molecules/mdx-image/index.ts
@@ -1,0 +1,2 @@
+export { MdxImage } from './mdx-image';
+export type { MdxImageProps } from './types';

--- a/components/molecules/mdx-image/mdx-image.tsx
+++ b/components/molecules/mdx-image/mdx-image.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+
+import type { MdxImageProps } from './types';
+
+/* 記事本文(article)のprose最大幅(app/blog/[...slug]/container.tsx の max-w-[42rem])に合わせる */
+const CONTENT_MAX_WIDTH = 672;
+
+export const MdxImage = ({ alt = '', height, src, width }: MdxImageProps) => {
+  const numericWidth = width ? Number(width) : undefined;
+  const numericHeight = height ? Number(height) : undefined;
+
+  if (!src || !numericWidth || !numericHeight) {
+    /* 外部URL等、ビルド時に実寸を取得できなかった画像はnext/imageの最適化を諦め、
+       素のimgでそのまま表示する(remark-resolve-imagesを参照) */
+    return <img src={src} alt={alt} loading="lazy" />;
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={numericWidth}
+      height={numericHeight}
+      sizes={`(min-width: ${CONTENT_MAX_WIDTH}px) ${CONTENT_MAX_WIDTH}px, 100vw`}
+      className="h-auto w-full rounded-xl"
+    />
+  );
+};

--- a/components/molecules/mdx-image/types.ts
+++ b/components/molecules/mdx-image/types.ts
@@ -1,0 +1,6 @@
+export interface MdxImageProps {
+  alt?: string;
+  height?: number | string;
+  src?: string;
+  width?: number | string;
+}

--- a/components/organisms/article-card/article-card.tsx
+++ b/components/organisms/article-card/article-card.tsx
@@ -58,6 +58,7 @@ function CardBackground({
         src={eyecatch.url}
         alt=""
         fill
+        sizes="(min-width: 640px) 420px, 100vw"
         className="object-cover transition-transform duration-500 group-hover:scale-105"
         priority={priority}
       />

--- a/components/organisms/post-list/post-list.tsx
+++ b/components/organisms/post-list/post-list.tsx
@@ -13,9 +13,11 @@ const AD_INTERVAL = 6;
 interface PostListProps {
   basePath?: string;
   posts: BaseContentMetadata[];
+  /** 一覧の先頭カード(LCP候補)にpriorityを付けるか。関連記事など画面外に出る一覧では付けない */
+  prioritizeFirst?: boolean;
 }
 
-export function PostList({ basePath = '/blog', posts }: PostListProps) {
+export function PostList({ basePath = '/blog', posts, prioritizeFirst = false }: PostListProps) {
   if (posts.length === 0) {
     return <EmptyState />;
   }
@@ -35,6 +37,7 @@ export function PostList({ basePath = '/blog', posts }: PostListProps) {
               description={post.description}
               eyecatch={post.eyecatch}
               isExternal={false}
+              priority={prioritizeFirst && index === 0}
             />
             {showAd && <PromoCard seed={Math.floor(index / AD_INTERVAL)} />}
           </Fragment>

--- a/lib/blog-content/content-renderer.test.tsx
+++ b/lib/blog-content/content-renderer.test.tsx
@@ -4,6 +4,24 @@ import { PassThrough } from 'node:stream';
 import type { ReactNode } from 'react';
 import { renderMarkdownContent } from './content-renderer';
 
+/* デフォルトは「実ファイルなし」= 既存の画像テストはフォールバック(素のimg)のまま動く。
+   実寸を検証したいテストだけmockReturnValueOnceで個別に上書きする。 */
+const { existsSyncMock, readFileSyncMock, imageSizeMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn().mockReturnValue(false),
+  readFileSyncMock: vi.fn(),
+  imageSizeMock: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  default: { existsSync: existsSyncMock, readFileSync: readFileSyncMock },
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+vi.mock('image-size', () => ({
+  imageSize: imageSizeMock,
+}));
+
 /**
  * CodeBlockはSuspense境界のないasyncサーバーコンポーネントのため、
  * 同期APIのrenderToStaticMarkupではサスペンドしてエラーになる。
@@ -109,6 +127,20 @@ describe('renderMarkdownContent', () => {
     const markup = renderToStaticMarkup(content);
 
     expect(markup).toContain(`/blog-assets/${SLUG}/images/eyecatch.png`);
+  });
+
+  it('実寸が取得できたローカル画像はnext/image(width/height付き)でレンダリングされる', async () => {
+    existsSyncMock.mockReturnValueOnce(true);
+    readFileSyncMock.mockReturnValueOnce(new Uint8Array());
+    imageSizeMock.mockReturnValueOnce({ width: 800, height: 600 });
+
+    const markdown = '![alt text](images/photo.png)';
+    const { content } = await renderMarkdownContent(markdown, SLUG);
+    const markup = renderToStaticMarkup(content);
+
+    expect(markup).toContain('width="800"');
+    expect(markup).toContain('height="600"');
+    expect(markup).toContain('alt="alt text"');
   });
 
   it('product-linkタグが各ストアの検索リンクカードに変換される', async () => {

--- a/lib/blog-content/content-renderer.tsx
+++ b/lib/blog-content/content-renderer.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 import { CodeBlock } from '@/components/molecules/code-block';
 import { MdxBlockquote } from '@/components/molecules/mdx-blockquote';
 import { MdxH1, MdxH2, MdxH3, MdxH4, MdxH5, MdxH6 } from '@/components/molecules/mdx-heading';
+import { MdxImage } from '@/components/molecules/mdx-image';
 import { MdxTable } from '@/components/molecules/mdx-table';
 import { ContentLinkCard as ContentLinkCardAsync } from '@/components/organisms/content-link-card/content-link-card';
 import { ProductLink } from '@/components/organisms/product-link/product-link';
@@ -51,6 +52,7 @@ const components = {
   h4: MdxH4,
   h5: MdxH5,
   h6: MdxH6,
+  img: MdxImage,
   table: MdxTable,
 };
 

--- a/lib/blog-content/paths.ts
+++ b/lib/blog-content/paths.ts
@@ -11,7 +11,7 @@ export const slugToIndexFile = (slug: string): string =>
   path.join(slugToArticleDir(slug), INDEX_FILE_NAME);
 
 /* 絶対URL・ルート相対URL・data URIはそのまま外部/既解決のURLとして扱う */
-const isResolvedUrl = (url: string): boolean =>
+export const isResolvedUrl = (url: string): boolean =>
   url.startsWith('http://') ||
   url.startsWith('https://') ||
   url.startsWith('/') ||

--- a/lib/blog-content/remark-resolve-images.test.ts
+++ b/lib/blog-content/remark-resolve-images.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import type { Root, Element } from 'hast';
+import { visit } from 'unist-util-visit';
+import { remarkResolveImages } from './remark-resolve-images';
+
+const { existsSyncMock, readFileSyncMock, imageSizeMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  imageSizeMock: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  default: { existsSync: existsSyncMock, readFileSync: readFileSyncMock },
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+vi.mock('image-size', () => ({
+  imageSize: imageSizeMock,
+}));
+
+const SLUG = 'sample-post';
+
+const markdownToHast = async (markdown: string): Promise<Root> => {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkResolveImages, { slug: SLUG })
+    .use(remarkRehype);
+  const mdast = processor.parse(markdown);
+  return (await processor.run(mdast)) as Root;
+};
+
+const findElement = (tree: Root, tagName: string): Element | undefined => {
+  let found: Element | undefined;
+  visit(tree, 'element', (node: Element) => {
+    if (node.tagName === tagName) {
+      found = node;
+    }
+  });
+  return found;
+};
+
+describe('remarkResolveImages', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset();
+    readFileSyncMock.mockReset();
+    imageSizeMock.mockReset();
+  });
+
+  it('ローカル画像は配信URLへ解決され、実寸がwidth/heightへ埋め込まれる', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(new Uint8Array());
+    imageSizeMock.mockReturnValue({ width: 800, height: 600 });
+
+    const hast = await markdownToHast('![alt](images/foo.png)');
+
+    const img = findElement(hast, 'img');
+    expect(img?.properties?.src).toBe(`/blog-assets/${SLUG}/images/foo.png`);
+    expect(img?.properties?.width).toBe(800);
+    expect(img?.properties?.height).toBe(600);
+  });
+
+  it('外部URL画像はローカルファイル判定をスキップし、width/heightを付与しない', async () => {
+    const hast = await markdownToHast('![alt](https://example.com/foo.png)');
+
+    expect(existsSyncMock).not.toHaveBeenCalled();
+    const img = findElement(hast, 'img');
+    expect(img?.properties?.src).toBe('https://example.com/foo.png');
+    expect(img?.properties?.width).toBeUndefined();
+    expect(img?.properties?.height).toBeUndefined();
+  });
+
+  it('実ファイルが存在しない場合はURLだけ解決し、width/heightを付与しない', async () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const hast = await markdownToHast('![alt](images/missing.png)');
+
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+    const img = findElement(hast, 'img');
+    expect(img?.properties?.src).toBe(`/blog-assets/${SLUG}/images/missing.png`);
+    expect(img?.properties?.width).toBeUndefined();
+    expect(img?.properties?.height).toBeUndefined();
+  });
+
+  it('サイズ読み取りに失敗した場合もクラッシュせず、width/heightを付与しない', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(new Uint8Array());
+    imageSizeMock.mockImplementation(() => {
+      throw new Error('invalid image');
+    });
+
+    const hast = await markdownToHast('![alt](images/broken.png)');
+
+    const img = findElement(hast, 'img');
+    expect(img?.properties?.src).toBe(`/blog-assets/${SLUG}/images/broken.png`);
+    expect(img?.properties?.width).toBeUndefined();
+    expect(img?.properties?.height).toBeUndefined();
+  });
+});

--- a/lib/blog-content/remark-resolve-images.ts
+++ b/lib/blog-content/remark-resolve-images.ts
@@ -1,17 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { imageSize } from 'image-size';
 import { visit } from 'unist-util-visit';
 import type { Root, Image } from 'mdast';
 import type { Plugin } from 'unified';
-import { resolveAssetUrl } from './paths';
+import { isResolvedUrl, resolveAssetUrl, slugToArticleDir } from './paths';
 
 interface RemarkResolveImagesOptions {
   slug: string;
 }
 
-/** 記事本文中の相対画像パス(images/foo.png)を配信URL(/blog-assets/{slug}/images/foo.png)に書き換える */
+interface ImageDimensions {
+  height: number;
+  width: number;
+}
+
+/* ローカル画像(相対パス)は実ファイルを読んで実寸を取得し、hast要素のwidth/height
+   属性(next/imageのCLS防止に必須)へ埋め込む。外部URLや読み取り不能なファイルは
+   undefinedを返し、呼び出し側でサイズ無しの<img>フォールバックに委ねる */
+const getLocalImageDimensions = (
+  slug: string,
+  relativeUrl: string
+): ImageDimensions | undefined => {
+  const absolutePath = path.join(slugToArticleDir(slug), relativeUrl);
+  if (!existsSync(absolutePath)) {
+    return undefined;
+  }
+  try {
+    const { width, height } = imageSize(readFileSync(absolutePath));
+    return { width, height };
+  } catch {
+    return undefined;
+  }
+};
+
+/** 記事本文中の相対画像パス(images/foo.png)を配信URL(/blog-assets/{slug}/images/foo.png)に書き換え、
+    ローカル画像は実寸をhast要素のwidth/height属性として埋め込む(mdast-util-to-hastのdata.hPropertiesを利用) */
 export const remarkResolveImages: Plugin<[RemarkResolveImagesOptions], Root> = ({ slug }) => {
   return (tree: Root) => {
     visit(tree, 'image', (node: Image) => {
+      const dimensions = isResolvedUrl(node.url)
+        ? undefined
+        : getLocalImageDimensions(slug, node.url);
       node.url = resolveAssetUrl(slug, node.url);
+      if (dimensions) {
+        node.data = {
+          ...node.data,
+          hProperties: { ...node.data?.hProperties, ...dimensions },
+        };
+      }
     });
   };
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "hast-util-to-jsx-runtime": "^2.3.6",
+    "image-size": "^2.0.2",
     "lucide-react": "^0.555.0",
     "metadata-scraper": "^0.2.61",
     "next": "16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
+      image-size:
+        specifier: ^2.0.2
+        version: 2.0.2
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.1)


### PR DESCRIPTION
## Summary
- 記事本文中の画像がnext/imageを経由しない素の`<img>`のままで、元画像が未圧縮・未リサイズで配信されていた不具合を修正
  - `remark-resolve-images`でローカル画像は`image-size`により実寸をビルド時に取得しhastへ埋め込み
  - 新設の`MdxImage`コンポーネントでnext/image化(AVIF/WebP自動変換、レスポンシブsrcset)
  - 外部URL画像(remotePatterns対象外)は従来通り`<img loading="lazy">`にフォールバック
- 一覧カード(`ArticleCard`)の`fill`画像に`sizes`が無く、実表示サイズより大きい解像度をダウンロードしていた問題を修正
- 一覧先頭カード(LCP候補)に`priority`が付いておらず遅延読み込み対象になっていた問題を修正(トップページ・`/blog`一覧・タグ一覧。関連記事セクションは画面外のため対象外)

## Test plan
- [x] `pnpm check`(lint/format/tsc)
- [x] `pnpm test:unit`(43ファイル272件)
- [x] `pnpm build`
- [x] devサーバーで実機確認
  - 記事本文のローカル画像が`/_next/image?...`経由でwidth/height/srcset/sizes付きレンダリングされることを確認
  - 一覧カード画像に`sizes`が付与され、先頭カードのみ`loading`属性なし(eager)になることを確認
  - コンソールの`sizes`未指定警告・LCP警告が解消したことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
